### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/177/029/421177029.geojson
+++ b/data/421/177/029/421177029.geojson
@@ -329,6 +329,9 @@
     },
     "wof:country":"DO",
     "wof:created":1459009130,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6612048233ad04a4c119384399f31d2e",
     "wof:hierarchy":[
         {
@@ -340,7 +343,7 @@
         }
     ],
     "wof:id":421177029,
-    "wof:lastmodified":1566582315,
+    "wof:lastmodified":1582347720,
     "wof:name":"Santiago de los Caballeros",
     "wof:parent_id":1108721271,
     "wof:placetype":"locality",

--- a/data/421/197/155/421197155.geojson
+++ b/data/421/197/155/421197155.geojson
@@ -183,6 +183,9 @@
     },
     "wof:country":"DO",
     "wof:created":1459009904,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"227ac62a0299da9c832607c12d67b87d",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":421197155,
-    "wof:lastmodified":1566582313,
+    "wof:lastmodified":1582347720,
     "wof:name":"Cotu\u00ed",
     "wof:parent_id":890420147,
     "wof:placetype":"locality",

--- a/data/856/327/13/85632713.geojson
+++ b/data/856/327/13/85632713.geojson
@@ -977,6 +977,11 @@
     },
     "wof:country":"DO",
     "wof:country_alpha3":"DOM",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"2e2bf49c4db19df64007303025b74003",
     "wof:hierarchy":[
         {
@@ -991,7 +996,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581802,
+    "wof:lastmodified":1582347713,
     "wof:name":"Dominican Republic",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/705/37/85670537.geojson
+++ b/data/856/705/37/85670537.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Santiago Province (Dominican Republic)"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"26128af9cd7513919535ef4bf546a0e8",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581800,
+    "wof:lastmodified":1582347712,
     "wof:name":"Santiago",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/43/85670543.geojson
+++ b/data/856/705/43/85670543.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Santiago Rodr\u00edguez Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b0313197283742c4f14b6362450ce79",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581800,
+    "wof:lastmodified":1582347712,
     "wof:name":"Santiago Rodr\u00edguez",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/45/85670545.geojson
+++ b/data/856/705/45/85670545.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Valverde Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"018af3ada08e48df5118c47e6dd5a358",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581799,
+    "wof:lastmodified":1582347712,
     "wof:name":"Valverde",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/49/85670549.geojson
+++ b/data/856/705/49/85670549.geojson
@@ -297,6 +297,9 @@
         "wk:page":"San Juan Province (Dominican Republic)"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc798deae7f80e08d92da610a5a8dcbb",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581802,
+    "wof:lastmodified":1582347713,
     "wof:name":"San Juan",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/53/85670553.geojson
+++ b/data/856/705/53/85670553.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Santo Domingo Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc405817bcfde74bfc7981904d13d32b",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581800,
+    "wof:lastmodified":1582347712,
     "wof:name":"Santo Domingo",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/57/85670557.geojson
+++ b/data/856/705/57/85670557.geojson
@@ -274,6 +274,9 @@
         "wd:id":"Q1836903"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec38dc9dec00ae9b8602e00fc5962eda",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581798,
+    "wof:lastmodified":1582347712,
     "wof:name":"Sanchez Ram\u00edrez",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/63/85670563.geojson
+++ b/data/856/705/63/85670563.geojson
@@ -286,6 +286,9 @@
         "wd:id":"Q1366119"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3073e425839491fd8eb8003c561a1951",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581801,
+    "wof:lastmodified":1582347713,
     "wof:name":"San Pedro De Macor\u00eds",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/67/85670567.geojson
+++ b/data/856/705/67/85670567.geojson
@@ -285,6 +285,9 @@
         "wd:id":"Q592624"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9fe9192c1c98a98d5437bae1a5dc5a43",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581798,
+    "wof:lastmodified":1582347712,
     "wof:name":"Monte Cristi",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/71/85670571.geojson
+++ b/data/856/705/71/85670571.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Puerto Plata province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8d74bc2d580c77a6cdf420a1e381549",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581801,
+    "wof:lastmodified":1582347713,
     "wof:name":"Puerto Plata",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/75/85670575.geojson
+++ b/data/856/705/75/85670575.geojson
@@ -226,6 +226,9 @@
         "wk:page":"Dajab\u00f3n Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da8bf6a4adcebab0b3b0185f99a380af",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581799,
+    "wof:lastmodified":1582347712,
     "wof:name":"Dajab\u00f3n",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/81/85670581.geojson
+++ b/data/856/705/81/85670581.geojson
@@ -267,6 +267,9 @@
         "wk:page":"Espaillat Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"793e2faad0219cedf6ccc5f345d9625b",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581799,
+    "wof:lastmodified":1582347712,
     "wof:name":"Espaillat",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/83/85670583.geojson
+++ b/data/856/705/83/85670583.geojson
@@ -265,6 +265,9 @@
         "wk:page":"Hermanas Mirabal Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7227773148b30fe204614dab1b70ff2f",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581801,
+    "wof:lastmodified":1582347713,
     "wof:name":"Hermanas",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/89/85670589.geojson
+++ b/data/856/705/89/85670589.geojson
@@ -270,6 +270,9 @@
         "wd:id":"Q807079"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"523c85dedccb95db8009886b34d9b99a",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581798,
+    "wof:lastmodified":1582347712,
     "wof:name":"Bahoruco",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/91/85670591.geojson
+++ b/data/856/705/91/85670591.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Barahona Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30d39d02d48f2fa35fa07d4642224c60",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581800,
+    "wof:lastmodified":1582347712,
     "wof:name":"Barahona",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/97/85670597.geojson
+++ b/data/856/705/97/85670597.geojson
@@ -267,6 +267,9 @@
         "wk:page":"Independencia Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1599d77ab1c55870eeda75eb45e22a08",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581801,
+    "wof:lastmodified":1582347712,
     "wof:name":"Independencia",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/01/85670601.geojson
+++ b/data/856/706/01/85670601.geojson
@@ -285,6 +285,9 @@
         "wd:id":"Q1137545"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc4c012389b17c318da623204866d09d",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581796,
+    "wof:lastmodified":1582347711,
     "wof:name":"La Estrelleta",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/05/85670605.geojson
+++ b/data/856/706/05/85670605.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Pedernales Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c961b9077ec2afdc5db44b9cf85dcf33",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581794,
+    "wof:lastmodified":1582347711,
     "wof:name":"Pedernales",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/09/85670609.geojson
+++ b/data/856/706/09/85670609.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Azua Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6027157d669e9260e809b0621421a805",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581795,
+    "wof:lastmodified":1582347711,
     "wof:name":"Azua",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/15/85670615.geojson
+++ b/data/856/706/15/85670615.geojson
@@ -286,6 +286,9 @@
         "wk:page":"La Vega Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e545e03cb0d8c9b6aec894beec825c6b",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581797,
+    "wof:lastmodified":1582347712,
     "wof:name":"La Vega",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/19/85670619.geojson
+++ b/data/856/706/19/85670619.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Monse\u00f1or Nouel Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"687f54da1590b3030980fb91d5d77b19",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581795,
+    "wof:lastmodified":1582347711,
     "wof:name":"Monse\u00f1or Nouel",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/23/85670623.geojson
+++ b/data/856/706/23/85670623.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Peravia Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eeabdd2e7b7b4b826d2df1888988824c",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581797,
+    "wof:lastmodified":1582347711,
     "wof:name":"Peravia",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/27/85670627.geojson
+++ b/data/856/706/27/85670627.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q1424391"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bacb3c92dbdaee87172e6746bab9517",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581794,
+    "wof:lastmodified":1582347711,
     "wof:name":"San Jos\u00e9 De Ocoa",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/33/85670633.geojson
+++ b/data/856/706/33/85670633.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Duarte Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78a42baf6c2f0a18c8f8437625dd4feb",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581794,
+    "wof:lastmodified":1582347710,
     "wof:name":"Duarte",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/37/85670637.geojson
+++ b/data/856/706/37/85670637.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Hato Mayor Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e61135efdd9c2df79976a4d75ddc8298",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581795,
+    "wof:lastmodified":1582347711,
     "wof:name":"Hato Mayor",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/41/85670641.geojson
+++ b/data/856/706/41/85670641.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Monte Plata Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"901287c50256507af560956c4b39b286",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581797,
+    "wof:lastmodified":1582347711,
     "wof:name":"Monte Plata",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/45/85670645.geojson
+++ b/data/856/706/45/85670645.geojson
@@ -277,6 +277,9 @@
         "wd:id":"Q1949656"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"406d3cdb15962c22361680e3ea7cb046",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581794,
+    "wof:lastmodified":1582347711,
     "wof:name":"Mar\u00eda Trinidad S\u00e1nchez",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/53/85670653.geojson
+++ b/data/856/706/53/85670653.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Saman\u00e1 Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"accb1f843fd2852b1c680194c29738b8",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581795,
+    "wof:lastmodified":1582347711,
     "wof:name":"Saman\u00e1",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/55/85670655.geojson
+++ b/data/856/706/55/85670655.geojson
@@ -293,6 +293,9 @@
         "wk:page":"San Crist\u00f3bal Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a334db55b24664dcff510a08d115d2e",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581796,
+    "wof:lastmodified":1582347711,
     "wof:name":"San Crist\u00f3bal",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/59/85670659.geojson
+++ b/data/856/706/59/85670659.geojson
@@ -200,6 +200,9 @@
         "wk:page":"Distrito Nacional"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52196bc2a877c7f7f20967c6fdf3d705",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581793,
+    "wof:lastmodified":1582347710,
     "wof:name":"Distrito Nacional",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/63/85670663.geojson
+++ b/data/856/706/63/85670663.geojson
@@ -284,6 +284,9 @@
         "wk:page":"El Seibo Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddc867297dee0882df8a26f430af2159",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581796,
+    "wof:lastmodified":1582347711,
     "wof:name":"El Seybo",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/69/85670669.geojson
+++ b/data/856/706/69/85670669.geojson
@@ -273,6 +273,9 @@
         "wk:page":"La Altagracia Province"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68c093a24f3881e4e7fe5f2181d00d3b",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581793,
+    "wof:lastmodified":1582347710,
     "wof:name":"La Altagracia",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/73/85670673.geojson
+++ b/data/856/706/73/85670673.geojson
@@ -295,6 +295,9 @@
         "wd:id":"Q1140742"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"731128b571e3c295f949c0091f3c09c0",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566581795,
+    "wof:lastmodified":1582347711,
     "wof:name":"La Romana",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/857/937/01/85793701.geojson
+++ b/data/857/937/01/85793701.geojson
@@ -74,6 +74,9 @@
         "qs:id":953390
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1584641bd7a16e623eaed62b2de3af6",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347710,
     "wof:name":"Agua Dulce",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/05/85793705.geojson
+++ b/data/857/937/05/85793705.geojson
@@ -81,6 +81,9 @@
         "qs_pg:id":1146102
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b283a14be8982ea0e65c3b52848802ca",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347710,
     "wof:name":"Arroyo Hondo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/09/85793709.geojson
+++ b/data/857/937/09/85793709.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Bella Vista, Distrito Nacional"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a68ae7934275d32bc2f08ca1c86f823",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581792,
+    "wof:lastmodified":1582347710,
     "wof:name":"Bella Vista",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/11/85793711.geojson
+++ b/data/857/937/11/85793711.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Ciudad Nueva"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"124f317a7f4d85a73e1843be1d5b74cb",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ciudad Nueva",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/17/85793717.geojson
+++ b/data/857/937/17/85793717.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":232523
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3453463ab9a2f6cc3f14a6a1b5f3797",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347710,
     "wof:name":"El Algodonal",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/21/85793721.geojson
+++ b/data/857/937/21/85793721.geojson
@@ -95,6 +95,9 @@
         "gp:id":71492
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfe9e3fa5043d0424702d7207ddba459",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347710,
     "wof:name":"El Seis",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/25/85793725.geojson
+++ b/data/857/937/25/85793725.geojson
@@ -77,6 +77,9 @@
         "wd:id":"Q5379911"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0464e442ed8a73e3855ad9fdb843efea",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ensanche Bol\u00edvar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/29/85793729.geojson
+++ b/data/857/937/29/85793729.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":221945
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c771f40567133e8052328d4991b8087",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ensanche Independencia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/35/85793735.geojson
+++ b/data/857/937/35/85793735.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Ensanche La F\u00e9"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aba8aa8701659d192ec6cb1bebff4786",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ensanche la Fe",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/39/85793739.geojson
+++ b/data/857/937/39/85793739.geojson
@@ -74,6 +74,9 @@
         "qs:id":965532
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c1c86f59b687017a76fe1052e6b59c2",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ensanche Los Minas",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/41/85793741.geojson
+++ b/data/857/937/41/85793741.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":286172
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d11831187bdbaaf480d622beac0b2e2",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581793,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ensanche Ozama",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/45/85793745.geojson
+++ b/data/857/937/45/85793745.geojson
@@ -74,6 +74,9 @@
         "qs:id":1163186
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59c718310cca4205a28227147dc5a161",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ensanche Piantini",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/49/85793749.geojson
+++ b/data/857/937/49/85793749.geojson
@@ -85,6 +85,9 @@
         "qs_pg:id":232879
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35b8451957a74fd0c4e242aae27496aa",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581793,
+    "wof:lastmodified":1582347710,
     "wof:name":"Ferrand",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/55/85793755.geojson
+++ b/data/857/937/55/85793755.geojson
@@ -97,6 +97,9 @@
         "qs_pg:id":1116994
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fc8cc4bb2d0b4f684d277ff074d8857",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581792,
+    "wof:lastmodified":1582347710,
     "wof:name":"Gal\u00e1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/59/85793759.geojson
+++ b/data/857/937/59/85793759.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q5529031"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e483a13323b66d3087cb674e6abe4097",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347709,
     "wof:name":"Gascue",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/63/85793763.geojson
+++ b/data/857/937/63/85793763.geojson
@@ -104,6 +104,9 @@
         "qs_pg:id":1163265
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"188ff7e2d1adfadabf0f44e6d1528cc7",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581793,
+    "wof:lastmodified":1582347710,
     "wof:name":"Guibia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/65/85793765.geojson
+++ b/data/857/937/65/85793765.geojson
@@ -647,6 +647,9 @@
         "qs_pg:id":901101
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b92affbe3111ad939275dc1d900d8d6c",
     "wof:hierarchy":[
         {
@@ -662,7 +665,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581792,
+    "wof:lastmodified":1582347710,
     "wof:name":"Honduras",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/71/85793771.geojson
+++ b/data/857/937/71/85793771.geojson
@@ -103,6 +103,9 @@
         "qs_pg:id":958794
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1803fe064cfa7763a7f930039986ef9",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581793,
+    "wof:lastmodified":1582347710,
     "wof:name":"La Caridad",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/75/85793775.geojson
+++ b/data/857/937/75/85793775.geojson
@@ -83,6 +83,9 @@
         "wk:page":"La Esperilla"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24994bad750449a538348b0ef2992070",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581792,
+    "wof:lastmodified":1582347710,
     "wof:name":"La Esperilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/77/85793777.geojson
+++ b/data/857/937/77/85793777.geojson
@@ -102,6 +102,9 @@
         "qs:id":1151739
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c3a14c8a8260fa0c210f6a909ecc452",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347710,
     "wof:name":"La Far\u00eda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/81/85793781.geojson
+++ b/data/857/937/81/85793781.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":1152117
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b840805492decaf2108cc3d882a12e68",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581792,
+    "wof:lastmodified":1582347710,
     "wof:name":"La Fuente",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/85/85793785.geojson
+++ b/data/857/937/85/85793785.geojson
@@ -74,6 +74,9 @@
         "qs:id":1152141
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d83af539716b6849f0d97561fd4bd0d",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347710,
     "wof:name":"La Primavera",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/91/85793791.geojson
+++ b/data/857/937/91/85793791.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":1157495
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5d94c336a3aa4de165311c5225c4d87",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581792,
+    "wof:lastmodified":1582347710,
     "wof:name":"Los Mameyes",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/93/85793793.geojson
+++ b/data/857/937/93/85793793.geojson
@@ -73,6 +73,9 @@
         "gp:id":75399
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d48f45543e5f3d049c3e340121b58274",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347710,
     "wof:name":"Mosquiter\u00eda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/97/85793797.geojson
+++ b/data/857/937/97/85793797.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":1163834
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"468f1fd9145a1bcd770f420d6671c7f6",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581793,
+    "wof:lastmodified":1582347710,
     "wof:name":"Nibaje",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/937/99/85793799.geojson
+++ b/data/857/937/99/85793799.geojson
@@ -114,6 +114,9 @@
         "wk:page":"San Carlos, Distrito Nacional"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e41da7833389ebb28e468e78860515f",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581792,
+    "wof:lastmodified":1582347710,
     "wof:name":"San Carlos",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/03/85793803.geojson
+++ b/data/857/938/03/85793803.geojson
@@ -124,6 +124,9 @@
         "qs_pg:id":1165069
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"121870d3b3bec47ab0a47481541581c5",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581790,
+    "wof:lastmodified":1582347709,
     "wof:name":"Sans Souci",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/09/85793809.geojson
+++ b/data/857/938/09/85793809.geojson
@@ -239,6 +239,9 @@
         "qs_pg:id":1001523
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a9007f511aea125cd071ff72b7e4044",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347709,
     "wof:name":"Santa Cruz",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/13/85793813.geojson
+++ b/data/857/938/13/85793813.geojson
@@ -74,6 +74,9 @@
         "qs:id":1117080
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a29a700df28751a2153f9e4fd613e48b",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347709,
     "wof:name":"Timbeque",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/17/85793817.geojson
+++ b/data/857/938/17/85793817.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Villa Francisca"
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ff19d6b82353a8a30f5ffc48e3d539c",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581790,
+    "wof:lastmodified":1582347709,
     "wof:name":"Villa Francisca",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/19/85793819.geojson
+++ b/data/857/938/19/85793819.geojson
@@ -82,6 +82,9 @@
         "qs:id":1082597
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c5506676546b52b912a91efbe223590",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379288,
+    "wof:lastmodified":1582347709,
     "wof:name":"Villas Agr\u00edcolas N\u00famero Dos",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/25/85793825.geojson
+++ b/data/857/938/25/85793825.geojson
@@ -101,6 +101,9 @@
         "qs_pg:id":494644
     },
     "wof:country":"DO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b3a2325f034328ba292f0521d91c483",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566581791,
+    "wof:lastmodified":1582347709,
     "wof:name":"Villas Agr\u00edcolas N\u00famero Uno",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/420/137/890420137.geojson
+++ b/data/890/420/137/890420137.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051319,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7412dc33e15fffc43cca9528eded1b56",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890420137,
-    "wof:lastmodified":1566582354,
+    "wof:lastmodified":1582347723,
     "wof:name":"El Llano",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/890/420/141/890420141.geojson
+++ b/data/890/420/141/890420141.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051319,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd18d10675590b0d56e86f807941a7cf",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890420141,
-    "wof:lastmodified":1566582355,
+    "wof:lastmodified":1582347723,
     "wof:name":"El Factor",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/420/143/890420143.geojson
+++ b/data/890/420/143/890420143.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051319,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4424d66f9810312b5486b7f6a6074495",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890420143,
-    "wof:lastmodified":1566582354,
+    "wof:lastmodified":1582347723,
     "wof:name":"El Cercado",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/890/420/145/890420145.geojson
+++ b/data/890/420/145/890420145.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051319,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8e7260211a3a7cf9bbe89382cdf2b70",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890420145,
-    "wof:lastmodified":1566582354,
+    "wof:lastmodified":1582347723,
     "wof:name":"Duverg\u00e9",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/890/420/147/890420147.geojson
+++ b/data/890/420/147/890420147.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051320,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a4372a8aa334c751463b990263e4b5b",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":890420147,
-    "wof:lastmodified":1566582355,
+    "wof:lastmodified":1582347723,
     "wof:name":"Cotu\u00ed",
     "wof:parent_id":85670557,
     "wof:placetype":"county",

--- a/data/890/420/149/890420149.geojson
+++ b/data/890/420/149/890420149.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051320,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"570c65e6f6d4eb41e849c57045801184",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890420149,
-    "wof:lastmodified":1566582355,
+    "wof:lastmodified":1582347723,
     "wof:name":"Cevicos",
     "wof:parent_id":85670557,
     "wof:placetype":"county",

--- a/data/890/425/729/890425729.geojson
+++ b/data/890/425/729/890425729.geojson
@@ -296,6 +296,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051601,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b855a6d3a1bffd33338b4d6a1ea89ec",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         }
     ],
     "wof:id":890425729,
-    "wof:lastmodified":1566582321,
+    "wof:lastmodified":1582347720,
     "wof:name":"Tenares",
     "wof:parent_id":85670583,
     "wof:placetype":"county",

--- a/data/890/429/183/890429183.geojson
+++ b/data/890/429/183/890429183.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051799,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"768705c567d26b59950a1ac26deb08ac",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429183,
-    "wof:lastmodified":1566582352,
+    "wof:lastmodified":1582347723,
     "wof:name":"Yamas\u00e1",
     "wof:parent_id":85670641,
     "wof:placetype":"county",

--- a/data/890/429/185/890429185.geojson
+++ b/data/890/429/185/890429185.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051799,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af0df127a3b7285770477c81d2f050fb",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429185,
-    "wof:lastmodified":1566582353,
+    "wof:lastmodified":1582347723,
     "wof:name":"Yaguate",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/890/429/189/890429189.geojson
+++ b/data/890/429/189/890429189.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051799,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d311a6e312fb600853ddfca6a34560be",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429189,
-    "wof:lastmodified":1566582345,
+    "wof:lastmodified":1582347722,
     "wof:name":"Villa Tapia",
     "wof:parent_id":85670583,
     "wof:placetype":"county",

--- a/data/890/429/191/890429191.geojson
+++ b/data/890/429/191/890429191.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59fc13c84adb38f44c6e2d4680f77cd4",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429191,
-    "wof:lastmodified":1566582345,
+    "wof:lastmodified":1582347722,
     "wof:name":"Villa Riva",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/890/429/195/890429195.geojson
+++ b/data/890/429/195/890429195.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9079369ca5f2985552b1d441013029f",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429195,
-    "wof:lastmodified":1566582339,
+    "wof:lastmodified":1582347721,
     "wof:name":"Villa Jaragua",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/890/429/197/890429197.geojson
+++ b/data/890/429/197/890429197.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"818e03859c9da830c9c71b60eee2a43c",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890429197,
-    "wof:lastmodified":1566582346,
+    "wof:lastmodified":1582347722,
     "wof:name":"Villa Isabela",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/199/890429199.geojson
+++ b/data/890/429/199/890429199.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f039fa6b12abc8385a9b500ad5a0658a",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429199,
-    "wof:lastmodified":1566582347,
+    "wof:lastmodified":1582347722,
     "wof:name":"Villa Altagracia",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/890/429/201/890429201.geojson
+++ b/data/890/429/201/890429201.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f57eb03bd5cdd65fc0fa780caae72a42",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890429201,
-    "wof:lastmodified":1566582352,
+    "wof:lastmodified":1582347723,
     "wof:name":"Vicente Noble",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/890/429/203/890429203.geojson
+++ b/data/890/429/203/890429203.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1792561224442c7de834f1133a4cfcfa",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890429203,
-    "wof:lastmodified":1566582343,
+    "wof:lastmodified":1582347722,
     "wof:name":"Vallejuelo",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/890/429/205/890429205.geojson
+++ b/data/890/429/205/890429205.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d6760ee3f679212e217616a990ba473",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890429205,
-    "wof:lastmodified":1566582345,
+    "wof:lastmodified":1582347722,
     "wof:name":"Tamayo",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/890/429/207/890429207.geojson
+++ b/data/890/429/207/890429207.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c2ba99a670d4a3962bd922de1d88c82",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890429207,
-    "wof:lastmodified":1566582350,
+    "wof:lastmodified":1582347723,
     "wof:name":"Sos\u00faa",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/209/890429209.geojson
+++ b/data/890/429/209/890429209.geojson
@@ -423,6 +423,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051801,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"5d4bfed221e5868c53591c84494275e6",
     "wof:hierarchy":[
         {
@@ -434,7 +437,7 @@
         }
     ],
     "wof:id":890429209,
-    "wof:lastmodified":1566582350,
+    "wof:lastmodified":1582347723,
     "wof:name":"Santo Domingo",
     "wof:parent_id":1108721273,
     "wof:placetype":"locality",

--- a/data/890/429/213/890429213.geojson
+++ b/data/890/429/213/890429213.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051801,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f355da2c15bd4b7174ca54395dbb9d32",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":890429213,
-    "wof:lastmodified":1566582349,
+    "wof:lastmodified":1582347723,
     "wof:name":"San Francisco De Macor\u00eds",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/890/429/217/890429217.geojson
+++ b/data/890/429/217/890429217.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051801,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3320399e764a15df6aff6298d346680",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":890429217,
-    "wof:lastmodified":1566582341,
+    "wof:lastmodified":1582347721,
     "wof:name":"Sabana Grande De Boy\u00e1",
     "wof:parent_id":85670641,
     "wof:placetype":"county",

--- a/data/890/429/219/890429219.geojson
+++ b/data/890/429/219/890429219.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051801,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"656a6eb5712ce3eb3856c7a42cf2c28b",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":890429219,
-    "wof:lastmodified":1566582341,
+    "wof:lastmodified":1582347721,
     "wof:name":"Sabana De La Mar",
     "wof:parent_id":85670637,
     "wof:placetype":"county",

--- a/data/890/429/221/890429221.geojson
+++ b/data/890/429/221/890429221.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051801,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d33f0500af48df2349d4f8f545a42dc5",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890429221,
-    "wof:lastmodified":1566582340,
+    "wof:lastmodified":1582347721,
     "wof:name":"Ram\u00f3n Santana",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/890/429/223/890429223.geojson
+++ b/data/890/429/223/890429223.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051801,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3cefe5a506cb96ae12bd7bf43dca1bad",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429223,
-    "wof:lastmodified":1566582348,
+    "wof:lastmodified":1582347722,
     "wof:name":"Postrer R\u00edo",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/890/429/225/890429225.geojson
+++ b/data/890/429/225/890429225.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051801,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3499ddf5b946fe6cb9b70f03dad23f00",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":890429225,
-    "wof:lastmodified":1566582349,
+    "wof:lastmodified":1582347723,
     "wof:name":"Para\u00edso",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/890/429/227/890429227.geojson
+++ b/data/890/429/227/890429227.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c36273c6f9a0c3ca82df12025aede1a",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":890429227,
-    "wof:lastmodified":1566582339,
+    "wof:lastmodified":1582347721,
     "wof:name":"Padre Las Casas",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/890/429/231/890429231.geojson
+++ b/data/890/429/231/890429231.geojson
@@ -337,6 +337,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9968eebd2a54af526058fbce77abd25",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
         }
     ],
     "wof:id":890429231,
-    "wof:lastmodified":1566582349,
+    "wof:lastmodified":1582347723,
     "wof:name":"Oviedo",
     "wof:parent_id":85670605,
     "wof:placetype":"county",

--- a/data/890/429/233/890429233.geojson
+++ b/data/890/429/233/890429233.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9c7f47e6877a78f2846133b0075e879",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890429233,
-    "wof:lastmodified":1566582345,
+    "wof:lastmodified":1582347722,
     "wof:name":"Nizao",
     "wof:parent_id":85670623,
     "wof:placetype":"county",

--- a/data/890/429/235/890429235.geojson
+++ b/data/890/429/235/890429235.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"616d3019653be500704346c05e40cbc6",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":890429235,
-    "wof:lastmodified":1566582343,
+    "wof:lastmodified":1582347722,
     "wof:name":"Neiba",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/890/429/237/890429237.geojson
+++ b/data/890/429/237/890429237.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f19d60667ce94bdedd8c4d92c30d170",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":890429237,
-    "wof:lastmodified":1566582352,
+    "wof:lastmodified":1582347723,
     "wof:name":"Nagua",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/429/239/890429239.geojson
+++ b/data/890/429/239/890429239.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e99d32b984ddcafedcfa2605c467bd85",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890429239,
-    "wof:lastmodified":1566582351,
+    "wof:lastmodified":1582347723,
     "wof:name":"Monci\u00f3n",
     "wof:parent_id":85670543,
     "wof:placetype":"county",

--- a/data/890/429/241/890429241.geojson
+++ b/data/890/429/241/890429241.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051803,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da5fd8be0ca878407b6a6f3584e2c1bc",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890429241,
-    "wof:lastmodified":1566582347,
+    "wof:lastmodified":1582347722,
     "wof:name":"Moca",
     "wof:parent_id":85670581,
     "wof:placetype":"county",

--- a/data/890/429/243/890429243.geojson
+++ b/data/890/429/243/890429243.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051803,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8eb9384a3fa1c51faac652c39ef815b1",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429243,
-    "wof:lastmodified":1566582341,
+    "wof:lastmodified":1582347721,
     "wof:name":"Miches",
     "wof:parent_id":85670663,
     "wof:placetype":"county",

--- a/data/890/429/249/890429249.geojson
+++ b/data/890/429/249/890429249.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051803,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40ffb82ac631bc5484380317ac56f922",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":890429249,
-    "wof:lastmodified":1566582348,
+    "wof:lastmodified":1582347722,
     "wof:name":"Mao",
     "wof:parent_id":85670545,
     "wof:placetype":"county",

--- a/data/890/429/251/890429251.geojson
+++ b/data/890/429/251/890429251.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051803,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e4b760cca0714718f9b9d762d0c6852",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890429251,
-    "wof:lastmodified":1566582344,
+    "wof:lastmodified":1582347722,
     "wof:name":"Maim\u00f3n",
     "wof:parent_id":85670619,
     "wof:placetype":"county",

--- a/data/890/429/253/890429253.geojson
+++ b/data/890/429/253/890429253.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3cd1077a1d2f227245b77204ebb2d1ff",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":890429253,
-    "wof:lastmodified":1566582351,
+    "wof:lastmodified":1582347723,
     "wof:name":"Luper\u00f3n",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/255/890429255.geojson
+++ b/data/890/429/255/890429255.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d38a08d503e34d69b84a69206826b8f1",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":890429255,
-    "wof:lastmodified":1566582352,
+    "wof:lastmodified":1582347723,
     "wof:name":"Los Llanos",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/890/429/257/890429257.geojson
+++ b/data/890/429/257/890429257.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f72f3c0520f7cdba2e98f0675706dd91",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890429257,
-    "wof:lastmodified":1566582342,
+    "wof:lastmodified":1582347722,
     "wof:name":"Los Hidalgos",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/259/890429259.geojson
+++ b/data/890/429/259/890429259.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa060e8e4e537accd1e5e492799888b5",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890429259,
-    "wof:lastmodified":1566582342,
+    "wof:lastmodified":1582347722,
     "wof:name":"Cabrera",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/429/261/890429261.geojson
+++ b/data/890/429/261/890429261.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3af718d186ca8fb1b85f47abe5eed4e1",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890429261,
-    "wof:lastmodified":1566582342,
+    "wof:lastmodified":1582347722,
     "wof:name":"Licey Al Medio",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/890/429/263/890429263.geojson
+++ b/data/890/429/263/890429263.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"555f6c7d0782097d50adee78f17e193c",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890429263,
-    "wof:lastmodified":1566582352,
+    "wof:lastmodified":1582347723,
     "wof:name":"Las Matas De Santa Cruz",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/890/429/267/890429267.geojson
+++ b/data/890/429/267/890429267.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f5947a430a4690583f2dc20fb9d1ce3",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890429267,
-    "wof:lastmodified":1566582344,
+    "wof:lastmodified":1582347722,
     "wof:name":"Las Matas De Farf\u00e1n",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/890/429/269/890429269.geojson
+++ b/data/890/429/269/890429269.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac446cc005830a06cf938e551f658fab",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":890429269,
-    "wof:lastmodified":1566582344,
+    "wof:lastmodified":1582347722,
     "wof:name":"Jarabacoa",
     "wof:parent_id":85670615,
     "wof:placetype":"county",

--- a/data/890/429/271/890429271.geojson
+++ b/data/890/429/271/890429271.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dcfb85c16bb0ff41925e62475a13d219",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890429271,
-    "wof:lastmodified":1566582349,
+    "wof:lastmodified":1582347723,
     "wof:name":"J\u00e1nico",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/890/429/273/890429273.geojson
+++ b/data/890/429/273/890429273.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"059b87a34356ac95ab1a56ad98f4ec14",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":890429273,
-    "wof:lastmodified":1566582340,
+    "wof:lastmodified":1582347721,
     "wof:name":"Imbert",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/275/890429275.geojson
+++ b/data/890/429/275/890429275.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2393d0ec65e3d80f13faf7890c66b02",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890429275,
-    "wof:lastmodified":1566582341,
+    "wof:lastmodified":1582347722,
     "wof:name":"Hondo Valle",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/890/429/277/890429277.geojson
+++ b/data/890/429/277/890429277.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d61156b29919ec0a4e5d1d58dce5966e",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890429277,
-    "wof:lastmodified":1566582347,
+    "wof:lastmodified":1582347722,
     "wof:name":"Hig\u00fcey",
     "wof:parent_id":85670669,
     "wof:placetype":"county",

--- a/data/890/429/279/890429279.geojson
+++ b/data/890/429/279/890429279.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"afbd8abc177a65b24a5246ec180b27c6",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890429279,
-    "wof:lastmodified":1566582347,
+    "wof:lastmodified":1582347722,
     "wof:name":"Guayub\u00edn",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/890/429/281/890429281.geojson
+++ b/data/890/429/281/890429281.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e47e344c8c262176b1235caa2d09eec",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890429281,
-    "wof:lastmodified":1566582342,
+    "wof:lastmodified":1582347722,
     "wof:name":"Guaymate",
     "wof:parent_id":85670673,
     "wof:placetype":"county",

--- a/data/890/429/285/890429285.geojson
+++ b/data/890/429/285/890429285.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c756c4f942e8084c3d306c7a05014e48",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890429285,
-    "wof:lastmodified":1566582348,
+    "wof:lastmodified":1582347722,
     "wof:name":"Gaspar Hern\u00e1ndez",
     "wof:parent_id":85670581,
     "wof:placetype":"county",

--- a/data/890/429/287/890429287.geojson
+++ b/data/890/429/287/890429287.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d422223081347a488ff2217f248d925",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":890429287,
-    "wof:lastmodified":1566582340,
+    "wof:lastmodified":1582347721,
     "wof:name":"Fantino",
     "wof:parent_id":85670557,
     "wof:placetype":"county",

--- a/data/890/429/289/890429289.geojson
+++ b/data/890/429/289/890429289.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38348a801cbca21702493eb2816fce05",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":890429289,
-    "wof:lastmodified":1566582340,
+    "wof:lastmodified":1582347721,
     "wof:name":"Esperanza",
     "wof:parent_id":85670545,
     "wof:placetype":"county",

--- a/data/890/429/291/890429291.geojson
+++ b/data/890/429/291/890429291.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051806,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd48a8799fbb499344ed5b17f5de0e5f",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":890429291,
-    "wof:lastmodified":1566582351,
+    "wof:lastmodified":1582347723,
     "wof:name":"Enriquillo",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/890/429/293/890429293.geojson
+++ b/data/890/429/293/890429293.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051806,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0379fdeb82dfa98128320be97c2c231",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890429293,
-    "wof:lastmodified":1566582344,
+    "wof:lastmodified":1582347722,
     "wof:name":"Altamira",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/529/890429529.geojson
+++ b/data/890/429/529/890429529.geojson
@@ -268,6 +268,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469051819,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"41775babde6b05a5def57b4cbe0d948a",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         }
     ],
     "wof:id":890429529,
-    "wof:lastmodified":1566582345,
+    "wof:lastmodified":1582347722,
     "wof:name":"Comendador",
     "wof:parent_id":890453405,
     "wof:placetype":"locality",

--- a/data/890/436/811/890436811.geojson
+++ b/data/890/436/811/890436811.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052127,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38a058dae059a30a5b539a5d5fcee0a4",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890436811,
-    "wof:lastmodified":1566582326,
+    "wof:lastmodified":1582347721,
     "wof:name":"R\u00edo San Juan",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/438/115/890438115.geojson
+++ b/data/890/438/115/890438115.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052181,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7d23a7b5e4be59ef556fc35a5e93101",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890438115,
-    "wof:lastmodified":1566582329,
+    "wof:lastmodified":1582347721,
     "wof:name":"El Valle",
     "wof:parent_id":85670637,
     "wof:placetype":"county",

--- a/data/890/444/701/890444701.geojson
+++ b/data/890/444/701/890444701.geojson
@@ -263,6 +263,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052479,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0b6f08e29f71acd6132e1547a257316b",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         }
     ],
     "wof:id":890444701,
-    "wof:lastmodified":1566582331,
+    "wof:lastmodified":1582347721,
     "wof:name":"Santa B\u00e1rbara de Saman\u00e1",
     "wof:parent_id":1108721253,
     "wof:placetype":"locality",

--- a/data/890/444/719/890444719.geojson
+++ b/data/890/444/719/890444719.geojson
@@ -265,6 +265,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052479,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76762953afb585e28adeb7b1c09b4e4e",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         }
     ],
     "wof:id":890444719,
-    "wof:lastmodified":1566582338,
+    "wof:lastmodified":1582347721,
     "wof:name":"Moca",
     "wof:parent_id":890429241,
     "wof:placetype":"locality",

--- a/data/890/444/777/890444777.geojson
+++ b/data/890/444/777/890444777.geojson
@@ -244,6 +244,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052481,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"538c062e62b06b90ffbcde5977d959fe",
     "wof:hierarchy":[
         {
@@ -255,7 +258,7 @@
         }
     ],
     "wof:id":890444777,
-    "wof:lastmodified":1566582334,
+    "wof:lastmodified":1582347721,
     "wof:name":"El Guayabal",
     "wof:parent_id":1108721161,
     "wof:placetype":"locality",

--- a/data/890/444/785/890444785.geojson
+++ b/data/890/444/785/890444785.geojson
@@ -263,6 +263,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052481,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"65ccfb9db7d40170724d457abf37c1f1",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         }
     ],
     "wof:id":890444785,
-    "wof:lastmodified":1566582333,
+    "wof:lastmodified":1582347721,
     "wof:name":"Bonao",
     "wof:parent_id":1108721123,
     "wof:placetype":"locality",

--- a/data/890/453/401/890453401.geojson
+++ b/data/890/453/401/890453401.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052852,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76af01d7d10e4dd25219f177a1bee2d4",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890453401,
-    "wof:lastmodified":1566582330,
+    "wof:lastmodified":1582347721,
     "wof:name":"Constanza",
     "wof:parent_id":85670615,
     "wof:placetype":"county",

--- a/data/890/453/405/890453405.geojson
+++ b/data/890/453/405/890453405.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052852,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8054032c6b82e88b78e7c836d7c33667",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890453405,
-    "wof:lastmodified":1566582331,
+    "wof:lastmodified":1582347721,
     "wof:name":"Comendador",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/890/455/299/890455299.geojson
+++ b/data/890/455/299/890455299.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af0dc619989fe4a4ddeba37c930bfa29",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890455299,
-    "wof:lastmodified":1566582325,
+    "wof:lastmodified":1582347721,
     "wof:name":"San Rafael Del Yuma",
     "wof:parent_id":85670669,
     "wof:placetype":"county",

--- a/data/890/455/301/890455301.geojson
+++ b/data/890/455/301/890455301.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c13652a065e7039e86395dba293ca99",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":890455301,
-    "wof:lastmodified":1566582324,
+    "wof:lastmodified":1582347720,
     "wof:name":"San Jos\u00e9 De Las Matas",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/890/455/303/890455303.geojson
+++ b/data/890/455/303/890455303.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34aeaeca9711d25aa828e7090b35e8a3",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":890455303,
-    "wof:lastmodified":1566582324,
+    "wof:lastmodified":1582347720,
     "wof:name":"Pimentel",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/890/455/305/890455305.geojson
+++ b/data/890/455/305/890455305.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48f6058ff844d975192468e2c237252c",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":890455305,
-    "wof:lastmodified":1566582325,
+    "wof:lastmodified":1582347721,
     "wof:name":"Peralta",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/890/455/307/890455307.geojson
+++ b/data/890/455/307/890455307.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a47804ceb822a83bf20318e35c57dce",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":890455307,
-    "wof:lastmodified":1566582323,
+    "wof:lastmodified":1582347720,
     "wof:name":"Pepillo Salcedo",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/890/455/313/890455313.geojson
+++ b/data/890/455/313/890455313.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a99d206c83af7c534b223b5f6e3c386",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890455313,
-    "wof:lastmodified":1566582324,
+    "wof:lastmodified":1582347720,
     "wof:name":"Laguna Salada",
     "wof:parent_id":85670545,
     "wof:placetype":"county",

--- a/data/890/455/315/890455315.geojson
+++ b/data/890/455/315/890455315.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae496796881f96d9a00639b753d401c5",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890455315,
-    "wof:lastmodified":1566582324,
+    "wof:lastmodified":1582347720,
     "wof:name":"La Descubierta",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/890/455/317/890455317.geojson
+++ b/data/890/455/317/890455317.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"DO",
     "wof:created":1469052942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04cd20377a13f2ea7aa175aad0c8e6bc",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":890455317,
-    "wof:lastmodified":1566582325,
+    "wof:lastmodified":1582347721,
     "wof:name":"Jiman\u00ed",
     "wof:parent_id":85670597,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.