### PR TITLE
Update properties of megacities

### DIFF
--- a/data/890/429/209/890429209.geojson
+++ b/data/890/429/209/890429209.geojson
@@ -437,6 +437,7 @@
     "wof:concordances":{
         "gn:id":3492908,
         "gp:id":76456,
+        "ne:id":1159151401,
         "qs_pg:id":95714,
         "wd:id":"Q34820",
         "wk:page":"Santo Domingo"
@@ -463,7 +464,8 @@
         }
     ],
     "wof:id":890429209,
-    "wof:lastmodified":1607390874,
+    "wof:lastmodified":1608688185,
+    "wof:megacity":1,
     "wof:name":"Santo Domingo",
     "wof:parent_id":1108721273,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary