### PR TITLE
do concordances, placetype local, and more

### DIFF
--- a/data/110/872/110/3/1108721103.geojson
+++ b/data/110/872/110/3/1108721103.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DU.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133612,
     "wof:geomhash":"884114c3d1c56eeb3f86f85dcff3a328",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721103,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886541,
     "wof:name":"Arenoso",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/110/872/110/5/1108721105.geojson
+++ b/data/110/872/110/5/1108721105.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.PV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133613,
     "wof:geomhash":"804002d4f8eb185d7b6f1818b1b768ed",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721105,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"Azua",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/110/7/1108721107.geojson
+++ b/data/110/872/110/7/1108721107.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.CR.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133614,
     "wof:geomhash":"8a6509e473f936ece3774a15ffac9984",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721107,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886253,
     "wof:name":"Bajos De Haina",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/110/872/110/9/1108721109.geojson
+++ b/data/110/872/110/9/1108721109.geojson
@@ -104,6 +104,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PV.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133615,
     "wof:geomhash":"02de8cf9cbe65e7df1bfa2d22488c996",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108721109,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Ban\u00ed",
     "wof:parent_id":85670623,
     "wof:placetype":"county",

--- a/data/110/872/111/1/1108721111.geojson
+++ b/data/110/872/111/1/1108721111.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133616,
     "wof:geomhash":"ff7e9fa7dd8da9e6e29f9e9d84a6002b",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108721111,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886788,
     "wof:name":"Barahona",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/111/3/1108721113.geojson
+++ b/data/110/872/111/3/1108721113.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"DO.MP.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133617,
     "wof:geomhash":"14b87bf7a5d905f57941afd123b3fc15",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721113,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Bayaguana",
     "wof:parent_id":85670641,
     "wof:placetype":"county",

--- a/data/110/872/111/7/1108721117.geojson
+++ b/data/110/872/111/7/1108721117.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.VA.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133619,
     "wof:geomhash":"14badbdd8854d3926cb35d3d1aeb0dac",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721117,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886541,
     "wof:name":"Bison\u00f3",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/110/872/111/9/1108721119.geojson
+++ b/data/110/872/111/9/1108721119.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SD.BC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133620,
     "wof:geomhash":"65f05fd59dcca59103abc3a95b0b0af8",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108721119,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"Boca Chica",
     "wof:parent_id":85670553,
     "wof:placetype":"county",

--- a/data/110/872/112/1/1108721121.geojson
+++ b/data/110/872/112/1/1108721121.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.JU.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133621,
     "wof:geomhash":"57d0fa5be302fa6611f813cd879cf873",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721121,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"Bohech\u00edo",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/110/872/112/3/1108721123.geojson
+++ b/data/110/872/112/3/1108721123.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"DO.MN.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133622,
     "wof:geomhash":"c3ed636d77f25eca93bc131e58fe40b4",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108721123,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"Bonao",
     "wof:parent_id":85670619,
     "wof:placetype":"county",

--- a/data/110/872/112/5/1108721125.geojson
+++ b/data/110/872/112/5/1108721125.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.EP.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133624,
     "wof:geomhash":"760d5c0a45e9e2cc28f26633161ad74e",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721125,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886541,
     "wof:name":"B\u00e1nica",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/110/872/112/7/1108721127.geojson
+++ b/data/110/872/112/7/1108721127.geojson
@@ -95,6 +95,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133625,
     "wof:geomhash":"00723136b80b88d58b44bcfd64ba8ba4",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108721127,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Cabral",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/112/9/1108721129.geojson
+++ b/data/110/872/112/9/1108721129.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"DO.CR.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133626,
     "wof:geomhash":"78dd34bc1e34937c8d7fd782805abbfa",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721129,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"Cambita Garabitos",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/110/872/113/1/1108721131.geojson
+++ b/data/110/872/113/1/1108721131.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.MC.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133627,
     "wof:geomhash":"e0239b94378076f0cd03860a30e3624b",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721131,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886274,
     "wof:name":"Casta\u00f1uelas",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/110/872/113/5/1108721135.geojson
+++ b/data/110/872/113/5/1108721135.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DU.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133629,
     "wof:geomhash":"9c578808fdcf31928ef30172ad2fb939",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108721135,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Castillo",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/110/872/113/7/1108721137.geojson
+++ b/data/110/872/113/7/1108721137.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.ES.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133630,
     "wof:geomhash":"f5a7578741c6ad93955c676136274cfb",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721137,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"Cayetano Germos\u00e9n",
     "wof:parent_id":85670581,
     "wof:placetype":"county",

--- a/data/110/872/113/9/1108721139.geojson
+++ b/data/110/872/113/9/1108721139.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PM.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133632,
     "wof:geomhash":"4e1d0c8bf29d187d33515b4fda99df8b",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721139,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"Consuelo",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/110/872/114/1/1108721141.geojson
+++ b/data/110/872/114/1/1108721141.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"DO.IN.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133634,
     "wof:geomhash":"61c6e5c7401476c5f1052f27c05750d1",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108721141,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Crist\u00f3bal",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/110/872/114/3/1108721143.geojson
+++ b/data/110/872/114/3/1108721143.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133636,
     "wof:geomhash":"c3b3fdfe11f0010f0ec7a709e35373f6",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108721143,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"El Pe\u00f1\u00f3n",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/114/5/1108721145.geojson
+++ b/data/110/872/114/5/1108721145.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DA.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133638,
     "wof:geomhash":"6145ab784706c6ccefe0faee7e443994",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721145,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"El Pino",
     "wof:parent_id":85670575,
     "wof:placetype":"county",

--- a/data/110/872/114/7/1108721147.geojson
+++ b/data/110/872/114/7/1108721147.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SE.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133639,
     "wof:geomhash":"b513868a2392dcf6dcb72f8664215ef9",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108721147,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886789,
     "wof:name":"El Seibo",
     "wof:parent_id":85670663,
     "wof:placetype":"county",

--- a/data/110/872/114/9/1108721149.geojson
+++ b/data/110/872/114/9/1108721149.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133641,
     "wof:geomhash":"a37a3da73223e5b07f6b37a5f44e4471",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721149,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"Esteban\u00eda",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/115/3/1108721153.geojson
+++ b/data/110/872/115/3/1108721153.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DU.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133642,
     "wof:geomhash":"83ed488be289ed10c0fb6ca994c29b33",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721153,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886291,
     "wof:name":"Eugenio Mar\u00eda De Hostos",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/110/872/115/5/1108721155.geojson
+++ b/data/110/872/115/5/1108721155.geojson
@@ -101,6 +101,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.FU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133644,
     "wof:geomhash":"7973aeb66fce4340ba668f86a02283a4",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108721155,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Fundaci\u00f3n",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/115/7/1108721157.geojson
+++ b/data/110/872/115/7/1108721157.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BR.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133645,
     "wof:geomhash":"b38044d5167c2ee5c5075f0e8ad60550",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721157,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886292,
     "wof:name":"Galv\u00e1n",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/110/872/115/9/1108721159.geojson
+++ b/data/110/872/115/9/1108721159.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PP.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133646,
     "wof:geomhash":"6c5378a2320a2292e3b6831621a7acc4",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721159,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886542,
     "wof:name":"Guananico",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/110/872/116/1/1108721161.geojson
+++ b/data/110/872/116/1/1108721161.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133647,
     "wof:geomhash":"6d19894deeec81fcfbf4046fd03745b3",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721161,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Guayabal",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/116/3/1108721163.geojson
+++ b/data/110/872/116/3/1108721163.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PM.GY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133649,
     "wof:geomhash":"c0cbbe3c2ed6abc177c66a4fde0380ad",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108721163,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886543,
     "wof:name":"Guayacanes",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/110/872/116/5/1108721165.geojson
+++ b/data/110/872/116/5/1108721165.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.HM.HM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133651,
     "wof:geomhash":"e77147f9aa23b16d19aa96462f388955",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721165,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886788,
     "wof:name":"Hato Mayor",
     "wof:parent_id":85670637,
     "wof:placetype":"county",

--- a/data/110/872/116/7/1108721167.geojson
+++ b/data/110/872/116/7/1108721167.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.ES.JN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133653,
     "wof:geomhash":"b132a3505f881482a158156619530f76",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721167,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886309,
     "wof:name":"Jamao Al Norte",
     "wof:parent_id":85670581,
     "wof:placetype":"county",

--- a/data/110/872/117/1/1108721171.geojson
+++ b/data/110/872/117/1/1108721171.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.VN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133654,
     "wof:geomhash":"9f721d3653fda8d8c24a46c599d16c17",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721171,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886543,
     "wof:name":"Jaquimeyes",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/117/3/1108721173.geojson
+++ b/data/110/872/117/3/1108721173.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.VE.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133656,
     "wof:geomhash":"7b1647b79bd99f85c02e3a4cdedb3347",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721173,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886543,
     "wof:name":"Jima Abajo",
     "wof:parent_id":85670615,
     "wof:placetype":"county",

--- a/data/110/872/117/5/1108721175.geojson
+++ b/data/110/872/117/5/1108721175.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.JU.JH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133658,
     "wof:geomhash":"0072e65acc164d78f34edc58025a2597",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721175,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886311,
     "wof:name":"Juan De Herrera",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/110/872/117/7/1108721177.geojson
+++ b/data/110/872/117/7/1108721177.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"DO.EP.JS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133659,
     "wof:geomhash":"f0a0d0d7946f95d56734cb4c36a52833",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108721177,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886311,
     "wof:name":"Juan Santiago",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/110/872/117/9/1108721179.geojson
+++ b/data/110/872/117/9/1108721179.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133660,
     "wof:geomhash":"b01cf3c88a4bb0ff2718c914236cf75a",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721179,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886543,
     "wof:name":"La Ci\u00e9naga",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/118/1/1108721181.geojson
+++ b/data/110/872/118/1/1108721181.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SZ.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133662,
     "wof:geomhash":"eedb7656df85e200824ab92118fbaae6",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108721181,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"La Mata",
     "wof:parent_id":85670557,
     "wof:placetype":"county",

--- a/data/110/872/118/3/1108721183.geojson
+++ b/data/110/872/118/3/1108721183.geojson
@@ -113,6 +113,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AL.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133663,
     "wof:geomhash":"eeb850bdf0de82e19bc59e644eada25b",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108721183,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"La Romana",
     "wof:parent_id":85670673,
     "wof:placetype":"county",

--- a/data/110/872/118/5/1108721185.geojson
+++ b/data/110/872/118/5/1108721185.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"DO.VE.CV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133664,
     "wof:geomhash":"5aaf03f59f36ea312c9b98b6d769defa",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108721185,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"La Vega",
     "wof:parent_id":85670615,
     "wof:placetype":"county",

--- a/data/110/872/118/9/1108721189.geojson
+++ b/data/110/872/118/9/1108721189.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133665,
     "wof:geomhash":"90896812543b44dff666cd49203b2e10",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721189,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Las Charcas",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/119/1/1108721191.geojson
+++ b/data/110/872/119/1/1108721191.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DU.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133667,
     "wof:geomhash":"a63252317bc61dee8eb66d4c596fe7ba",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721191,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Las Gu\u00e1ranas",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/110/872/119/3/1108721193.geojson
+++ b/data/110/872/119/3/1108721193.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.LS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133669,
     "wof:geomhash":"0fc991863d9730378022e7e35e460580",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721193,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Las Salinas",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/119/5/1108721195.geojson
+++ b/data/110/872/119/5/1108721195.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SM.LT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133670,
     "wof:geomhash":"6e62f8f9cfe5d330ee385a0a64f1261a",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108721195,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Las Terrenas",
     "wof:parent_id":85670653,
     "wof:placetype":"county",

--- a/data/110/872/119/7/1108721197.geojson
+++ b/data/110/872/119/7/1108721197.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.YV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133671,
     "wof:geomhash":"bde61e4f2d7551ca2234a22596b5c997",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721197,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886331,
     "wof:name":"Las Yayas De Viajama",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/119/9/1108721199.geojson
+++ b/data/110/872/119/9/1108721199.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DA.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133672,
     "wof:geomhash":"4105a41dae77d718c57d842636a5c953",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721199,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886336,
     "wof:name":"Loma De Cabrera",
     "wof:parent_id":85670575,
     "wof:placetype":"county",

--- a/data/110/872/120/1/1108721201.geojson
+++ b/data/110/872/120/1/1108721201.geojson
@@ -83,6 +83,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SD.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133673,
     "wof:geomhash":"f4f4a1d4029ec8527bf15ea40a257263",
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108721201,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Los Alcarrizos",
     "wof:parent_id":85670553,
     "wof:placetype":"county",

--- a/data/110/872/120/3/1108721203.geojson
+++ b/data/110/872/120/3/1108721203.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"DO.CR.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133674,
     "wof:geomhash":"67063ea0df0839d5c7bcab40f1c56c84",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108721203,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Los Cacaos",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/110/872/120/7/1108721207.geojson
+++ b/data/110/872/120/7/1108721207.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BR.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133676,
     "wof:geomhash":"2ab2255a0050fb6135fe4e102297b2a4",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108721207,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Los R\u00edos",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/110/872/120/9/1108721209.geojson
+++ b/data/110/872/120/9/1108721209.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"DO.IN.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133678,
     "wof:geomhash":"8906a34f759ac9e7426f8f9437ffbc45",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108721209,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Mella",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/110/872/121/1/1108721211.geojson
+++ b/data/110/872/121/1/1108721211.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.MC.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133681,
     "wof:geomhash":"8e17925283c87982312d38d068b6ae74",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721211,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"Monte Cristi",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/110/872/121/3/1108721213.geojson
+++ b/data/110/872/121/3/1108721213.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"DO.MP.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133682,
     "wof:geomhash":"f53544b5d4c627201ff09659b6e965a5",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108721213,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"Monte Plata",
     "wof:parent_id":85670641,
     "wof:placetype":"county",

--- a/data/110/872/121/5/1108721215.geojson
+++ b/data/110/872/121/5/1108721215.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DA.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133686,
     "wof:geomhash":"789ca32527777a9a98e6321c093c7e00",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721215,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Partido",
     "wof:parent_id":85670575,
     "wof:placetype":"county",

--- a/data/110/872/121/7/1108721217.geojson
+++ b/data/110/872/121/7/1108721217.geojson
@@ -104,6 +104,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PN.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133687,
     "wof:geomhash":"3d05ab2010c5d62bf88e0e8f4664a980",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108721217,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"Pedernales",
     "wof:parent_id":85670605,
     "wof:placetype":"county",

--- a/data/110/872/121/9/1108721219.geojson
+++ b/data/110/872/121/9/1108721219.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SD.PB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133688,
     "wof:geomhash":"8d1ba474c06a9720df7082df0ca171ff",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721219,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Pedro Brand",
     "wof:parent_id":85670553,
     "wof:placetype":"county",

--- a/data/110/872/122/1/1108721221.geojson
+++ b/data/110/872/122/1/1108721221.geojson
@@ -95,6 +95,7 @@
     "wof:concordances":{
         "hasc:id":"DO.EP.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133695,
     "wof:geomhash":"f64c659c9952ea9cde71e413cf046993",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108721221,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Pedro Santana",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/110/872/122/5/1108721225.geojson
+++ b/data/110/872/122/5/1108721225.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.MP.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133697,
     "wof:geomhash":"50f227b71aaa0b12a9eacae9aa43c01b",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721225,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886544,
     "wof:name":"Peralvillo",
     "wof:parent_id":85670641,
     "wof:placetype":"county",

--- a/data/110/872/122/7/1108721227.geojson
+++ b/data/110/872/122/7/1108721227.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.MN.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133698,
     "wof:geomhash":"33c947649087d6f7c41350873afff504",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721227,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Piedra Blanca",
     "wof:parent_id":85670619,
     "wof:placetype":"county",

--- a/data/110/872/122/9/1108721229.geojson
+++ b/data/110/872/122/9/1108721229.geojson
@@ -242,6 +242,7 @@
     "wof:concordances":{
         "hasc:id":"DO.BH.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133699,
     "wof:geomhash":"cd25dc50ad272646477ccf3795bd8387",
@@ -254,7 +255,7 @@
         }
     ],
     "wof:id":1108721229,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Polo",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/110/872/123/1/1108721231.geojson
+++ b/data/110/872/123/1/1108721231.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.PV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133701,
     "wof:geomhash":"e20733fa4838c7678afdc49f09894f9b",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721231,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Pueblo Viejo",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/123/3/1108721233.geojson
+++ b/data/110/872/123/3/1108721233.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PP.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133702,
     "wof:geomhash":"79e01a337f076a26d85e64bda92c92d8",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721233,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886789,
     "wof:name":"Puerto Plata",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/110/872/123/5/1108721235.geojson
+++ b/data/110/872/123/5/1108721235.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PM.QQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133703,
     "wof:geomhash":"6cae7deb9098cf6648b4c64ca986e9f4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721235,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Quisqueya",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/110/872/123/7/1108721237.geojson
+++ b/data/110/872/123/7/1108721237.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.JO.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133705,
     "wof:geomhash":"e0ba50ad4cf351930ddf86db542f5a22",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721237,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886545,
     "wof:name":"Rancho Arriba",
     "wof:parent_id":85670627,
     "wof:placetype":"county",

--- a/data/110/872/123/9/1108721239.geojson
+++ b/data/110/872/123/9/1108721239.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.DA.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133706,
     "wof:geomhash":"d48f47db4431e0f9803935bf2efedb3c",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721239,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886545,
     "wof:name":"Restauraci\u00f3n",
     "wof:parent_id":85670575,
     "wof:placetype":"county",

--- a/data/110/872/124/3/1108721243.geojson
+++ b/data/110/872/124/3/1108721243.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.CR.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133708,
     "wof:geomhash":"718982be766918ffe753a15a2e9cde12",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721243,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886393,
     "wof:name":"Sabana Grande De Palenque",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/110/872/124/5/1108721245.geojson
+++ b/data/110/872/124/5/1108721245.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.ST.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133710,
     "wof:geomhash":"09e9fc46f5e8f96b36ff07590c7c9f12",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721245,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sabana Iglesia",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/110/872/124/7/1108721247.geojson
+++ b/data/110/872/124/7/1108721247.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.JO.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133711,
     "wof:geomhash":"efcca3378394087d201781ed3fd8f184",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721247,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sabana Larga",
     "wof:parent_id":85670627,
     "wof:placetype":"county",

--- a/data/110/872/124/9/1108721249.geojson
+++ b/data/110/872/124/9/1108721249.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.SY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133712,
     "wof:geomhash":"04d9c01050e12e6ded2749aa9885522e",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721249,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sabana Yegua",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/125/1/1108721251.geojson
+++ b/data/110/872/125/1/1108721251.geojson
@@ -101,6 +101,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SC.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133712,
     "wof:geomhash":"86e059f1faf462c026006ba2447bdf37",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108721251,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886789,
     "wof:name":"Salcedo",
     "wof:parent_id":85670583,
     "wof:placetype":"county",

--- a/data/110/872/125/3/1108721253.geojson
+++ b/data/110/872/125/3/1108721253.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SM.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133713,
     "wof:geomhash":"1c46d716e05281e0611bb2bbe09b12aa",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721253,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886394,
     "wof:name":"Saman\u00e1",
     "wof:parent_id":85670653,
     "wof:placetype":"county",

--- a/data/110/872/125/5/1108721255.geojson
+++ b/data/110/872/125/5/1108721255.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SD.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133715,
     "wof:geomhash":"9df32ecc1ff2e47896cd284ca0be5182",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721255,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886394,
     "wof:name":"San Antonio De Guerra",
     "wof:parent_id":85670553,
     "wof:placetype":"county",

--- a/data/110/872/125/7/1108721257.geojson
+++ b/data/110/872/125/7/1108721257.geojson
@@ -137,6 +137,7 @@
     "wof:concordances":{
         "hasc:id":"DO.CR.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133716,
     "wof:geomhash":"969a268beb45c1b81c57c522dc51b05d",
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108721257,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"San Crist\u00f3bal",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/110/872/126/1/1108721261.geojson
+++ b/data/110/872/126/1/1108721261.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.CR.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133717,
     "wof:geomhash":"3beb720598546adab7a37b7a0917eab0",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721261,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886394,
     "wof:name":"San Gregorio De Nigua",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/110/872/126/3/1108721263.geojson
+++ b/data/110/872/126/3/1108721263.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SR.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133718,
     "wof:geomhash":"26c8600872ce114ae6b572df59fc1c73",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721263,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886394,
     "wof:name":"San Ignacio De Sabaneta",
     "wof:parent_id":85670543,
     "wof:placetype":"county",

--- a/data/110/872/126/5/1108721265.geojson
+++ b/data/110/872/126/5/1108721265.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.JO.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133720,
     "wof:geomhash":"15ba24bbf01afcf5fa6ce78c27ee024e",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721265,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886395,
     "wof:name":"San Jos\u00e9 De Ocoa",
     "wof:parent_id":85670627,
     "wof:placetype":"county",

--- a/data/110/872/126/7/1108721267.geojson
+++ b/data/110/872/126/7/1108721267.geojson
@@ -212,6 +212,7 @@
     "wof:concordances":{
         "hasc:id":"DO.JU.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133721,
     "wof:geomhash":"cb43c451158ce6271fb22bb367f1790b",
@@ -224,7 +225,7 @@
         }
     ],
     "wof:id":1108721267,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886789,
     "wof:name":"San Juan",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/110/872/126/9/1108721269.geojson
+++ b/data/110/872/126/9/1108721269.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PM.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133722,
     "wof:geomhash":"23327edae1725ee88a1efc199b24fa9c",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721269,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886396,
     "wof:name":"San Pedro De Macor\u00eds",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/110/872/127/1/1108721271.geojson
+++ b/data/110/872/127/1/1108721271.geojson
@@ -536,6 +536,7 @@
     "wof:concordances":{
         "hasc:id":"DO.ST.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133723,
     "wof:geomhash":"237008f86365f3c34560cae295d37d59",
@@ -548,7 +549,7 @@
         }
     ],
     "wof:id":1108721271,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886789,
     "wof:name":"Santiago",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/110/872/127/3/1108721273.geojson
+++ b/data/110/872/127/3/1108721273.geojson
@@ -50,6 +50,7 @@
     "wof:concordances":{
         "hasc:id":"DO.NC.DN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133725,
     "wof:geomhash":"d584d00b886e1a547d2f789714c477e5",
@@ -62,7 +63,7 @@
         }
     ],
     "wof:id":1108721273,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886396,
     "wof:name":"Santo Domingo De Guzm\u00e1n",
     "wof:parent_id":85670659,
     "wof:placetype":"county",

--- a/data/110/872/127/5/1108721275.geojson
+++ b/data/110/872/127/5/1108721275.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SD.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133726,
     "wof:geomhash":"d659f31c82a363cece2562a924384e55",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108721275,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886613,
     "wof:name":"Santo Domingo Este",
     "wof:parent_id":85670553,
     "wof:placetype":"county",

--- a/data/110/872/127/9/1108721279.geojson
+++ b/data/110/872/127/9/1108721279.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SD.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133727,
     "wof:geomhash":"26625c0f77f4579df56dc7045456b4f1",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108721279,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"Santo Domingo Norte",
     "wof:parent_id":85670553,
     "wof:placetype":"county",

--- a/data/110/872/128/1/1108721281.geojson
+++ b/data/110/872/128/1/1108721281.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SD.OE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133728,
     "wof:geomhash":"3ae5a1d92d476e85033d3d8ae3aff9f2",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721281,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"Santo Domingo Oeste",
     "wof:parent_id":85670553,
     "wof:placetype":"county",

--- a/data/110/872/128/3/1108721283.geojson
+++ b/data/110/872/128/3/1108721283.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SM.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133729,
     "wof:geomhash":"4703e0d5dd6f5ebdf9a1f9fbd49a0da7",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108721283,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"S\u00e1nchez",
     "wof:parent_id":85670653,
     "wof:placetype":"county",

--- a/data/110/872/128/5/1108721285.geojson
+++ b/data/110/872/128/5/1108721285.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"DO.ST.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133731,
     "wof:geomhash":"c7080d7097bbd3f1d9d37d9d4485d483",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108721285,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886409,
     "wof:name":"Tamboril",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/110/872/128/7/1108721287.geojson
+++ b/data/110/872/128/7/1108721287.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"DO.AZ.VT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133733,
     "wof:geomhash":"5c32c4f22f3a23c1b6b9ad12453c2234",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721287,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"T\u00e1bara Arriba",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/110/872/128/9/1108721289.geojson
+++ b/data/110/872/128/9/1108721289.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"DO.ST.VG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133735,
     "wof:geomhash":"2451cad9a808a6e4b5db4d70e1eb9f02",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108721289,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"Villa Gonz\u00e1lez",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/110/872/129/1/1108721291.geojson
+++ b/data/110/872/129/1/1108721291.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"DO.RO.VH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133736,
     "wof:geomhash":"277d8e701761e0b8a89acd0955506aa1",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108721291,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886546,
     "wof:name":"Villa Hermosa",
     "wof:parent_id":85670673,
     "wof:placetype":"county",

--- a/data/110/872/129/3/1108721293.geojson
+++ b/data/110/872/129/3/1108721293.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"DO.SR.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133738,
     "wof:geomhash":"6f863304e5f58129d37661f9a39c5e73",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108721293,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886549,
     "wof:name":"Villa Los Alm\u00e1cigos",
     "wof:parent_id":85670543,
     "wof:placetype":"county",

--- a/data/110/872/129/7/1108721297.geojson
+++ b/data/110/872/129/7/1108721297.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"DO.PP.VM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1476133739,
     "wof:geomhash":"b9a2b512776255644708320e416f36e9",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108721297,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886549,
     "wof:name":"Villa Montellano",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/856/327/13/85632713.geojson
+++ b/data/856/327/13/85632713.geojson
@@ -1189,6 +1189,7 @@
         "hasc:id":"DO",
         "icao:code":"HI",
         "ioc:id":"DOM",
+        "iso:code":"DO",
         "itu:id":"DOM",
         "loc:id":"n79094586",
         "m49:code":"214",
@@ -1203,6 +1204,7 @@
         "wk:page":"Dominican Republic",
         "wmo:id":"DR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:country_alpha3":"DOM",
     "wof:geom_alt":[
@@ -1224,7 +1226,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639538,
+    "wof:lastmodified":1695881195,
     "wof:name":"Dominican Republic",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/705/37/85670537.geojson
+++ b/data/856/705/37/85670537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.241352,
-    "geom:area_square_m":2816118214.153255,
+    "geom:area_square_m":2816118545.444931,
     "geom:bbox":"-71.253518,19.022085,-70.545,19.655",
     "geom:latitude":19.330148,
     "geom:longitude":-70.900197,
@@ -311,16 +311,18 @@
         "gn:id":3492918,
         "gp:id":2345193,
         "hasc:id":"DO.ST",
+        "iso:code":"DO-25",
         "iso:id":"DO-25",
         "qs_pg:id":219543,
         "wd:id":"Q1772983",
         "wk:page":"Santiago Province (Dominican Republic)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb83387000418749465773432fe5421d",
+    "wof:geomhash":"f63223cc012730d172a3d0c05474bdc0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875421,
+    "wof:lastmodified":1695884896,
     "wof:name":"Santiago",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/43/85670543.geojson
+++ b/data/856/705/43/85670543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098277,
-    "geom:area_square_m":1146358755.029764,
+    "geom:area_square_m":1146358705.232483,
     "geom:bbox":"-71.517168,19.169488,-71.082378,19.564994",
     "geom:latitude":19.379782,
     "geom:longitude":-71.323584,
@@ -289,17 +289,19 @@
         "gn:id":3492912,
         "gp:id":2345194,
         "hasc:id":"DO.SR",
+        "iso:code":"DO-26",
         "iso:id":"DO-26",
         "qs_pg:id":229372,
         "unlc:id":"DO-26",
         "wd:id":"Q2021942",
         "wk:page":"Santiago Rodr\u00edguez Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e5095bbb08d91bfad0919b48253fc8f",
+    "wof:geomhash":"c2932e987a987fa891d80213a460b4b3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875420,
+    "wof:lastmodified":1695884363,
     "wof:name":"Santiago Rodr\u00edguez",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/45/85670545.geojson
+++ b/data/856/705/45/85670545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07085,
-    "geom:area_square_m":825382829.504469,
+    "geom:area_square_m":825382742.311111,
     "geom:bbox":"-71.192245,19.437944,-70.876425,19.755205",
     "geom:latitude":19.585538,
     "geom:longitude":-71.04202,
@@ -290,17 +290,19 @@
         "gn:id":3492112,
         "gp:id":2345195,
         "hasc:id":"DO.VA",
+        "iso:code":"DO-27",
         "iso:id":"DO-27",
         "qs_pg:id":219544,
         "unlc:id":"DO-27",
         "wd:id":"Q1774848",
         "wk:page":"Valverde Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb007375fcf81a568441e059f95922c9",
+    "wof:geomhash":"6901985554cfcafc23cd077096a23217",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875419,
+    "wof:lastmodified":1695884896,
     "wof:name":"Valverde",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/49/85670549.geojson
+++ b/data/856/705/49/85670549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.288462,
-    "geom:area_square_m":3375042809.549847,
+    "geom:area_square_m":3375043379.659843,
     "geom:bbox":"-71.645399,18.585789,-70.891753,19.177912",
     "geom:latitude":18.876644,
     "geom:longitude":-71.289681,
@@ -317,17 +317,19 @@
         "gn:id":3493091,
         "gp:id":2345191,
         "hasc:id":"DO.JU",
+        "iso:code":"DO-22",
         "iso:id":"DO-22",
         "qs_pg:id":219542,
         "unlc:id":"DO-22",
         "wd:id":"Q2001793",
         "wk:page":"San Juan Province (Dominican Republic)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1bb0b6bcdaeee326fb22904e89d4ecc4",
+    "wof:geomhash":"e84a35a2370da87c7079b25cc995ed8e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -342,7 +344,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875422,
+    "wof:lastmodified":1695884896,
     "wof:name":"San Juan",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/53/85670553.geojson
+++ b/data/856/705/53/85670553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112107,
-    "geom:area_square_m":1314082379.638336,
+    "geom:area_square_m":1314082499.545897,
     "geom:bbox":"-70.171807,18.397888,-69.515,18.724873",
     "geom:latitude":18.565679,
     "geom:longitude":-69.847718,
@@ -298,17 +298,19 @@
         "gn:id":6201373,
         "gp:id":28358196,
         "hasc:id":"DO.SD",
+        "iso:code":"DO-32",
         "iso:id":"DO-32",
         "qs_pg:id":210730,
         "unlc:id":"DO-32",
         "wd:id":"Q1352536",
         "wk:page":"Santo Domingo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f569d9b7611982356ffb2369843809ec",
+    "wof:geomhash":"050c93451da2a06dd2f3ea19ce6dbd49",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875421,
+    "wof:lastmodified":1695884896,
     "wof:name":"Santo Domingo",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/57/85670557.geojson
+++ b/data/856/705/57/85670557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101771,
-    "geom:area_square_m":1189727176.341481,
+    "geom:area_square_m":1189727021.509819,
     "geom:bbox":"-70.375,18.845,-69.899125,19.165185",
     "geom:latitude":19.018361,
     "geom:longitude":-70.138376,
@@ -292,16 +292,18 @@
         "gn:id":3493192,
         "gp:id":2345190,
         "hasc:id":"DO.SZ",
+        "iso:code":"DO-24",
         "iso:id":"DO-24",
         "qs_pg:id":221720,
         "unlc:id":"DO-24",
         "wd:id":"Q1836903"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2a691d50e0987c17c58850f554306d5e",
+    "wof:geomhash":"2d6b7beefebac88b06bad79fe9ea265a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875418,
+    "wof:lastmodified":1695884363,
     "wof:name":"Sanchez Ram\u00edrez",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/63/85670563.geojson
+++ b/data/856/705/63/85670563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108628,
-    "geom:area_square_m":1273421023.192235,
+    "geom:area_square_m":1273421023.192111,
     "geom:bbox":"-69.6048394856,18.391222,-69.0695353463,18.8160751261",
     "geom:latitude":18.549954,
     "geom:longitude":-69.360514,
@@ -280,16 +280,18 @@
         "gn:id":3493031,
         "gp:id":2345192,
         "hasc:id":"DO.PM",
+        "iso:code":"DO-23",
         "iso:id":"DO-23",
         "qs_pg:id":221721,
         "unlc:id":"DO-23",
         "wd:id":"Q1366119"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3073e425839491fd8eb8003c561a1951",
+    "wof:geomhash":"1eaa9a6762e13b1e727140f2685e64b3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582347713,
+    "wof:lastmodified":1695884364,
     "wof:name":"San Pedro De Macor\u00eds",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/67/85670567.geojson
+++ b/data/856/705/67/85670567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.184449,
-    "geom:area_square_m":2147208771.335944,
+    "geom:area_square_m":2147208687.110435,
     "geom:bbox":"-71.779663,19.49626,-71.135,19.913805",
     "geom:latitude":19.703292,
     "geom:longitude":-71.471545,
@@ -309,16 +309,18 @@
         "gn:id":3496200,
         "gp:id":2345184,
         "hasc:id":"DO.MC",
+        "iso:code":"DO-15",
         "iso:id":"DO-15",
         "qs_pg:id":430951,
         "unlc:id":"DO-15",
         "wd:id":"Q592624"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b076ad0912437d791f59d18b0a215ae4",
+    "wof:geomhash":"48fdb90c2f0e83ecda9156b5fff292b9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875419,
+    "wof:lastmodified":1695884896,
     "wof:name":"Monte Cristi",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/71/85670571.geojson
+++ b/data/856/705/71/85670571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157328,
-    "geom:area_square_m":1831010283.441654,
+    "geom:area_square_m":1831009877.919427,
     "geom:bbox":"-71.252414,19.515,-70.365952,19.933805",
     "geom:latitude":19.745527,
     "geom:longitude":-70.799869,
@@ -310,17 +310,19 @@
         "gn:id":3494267,
         "gp:id":2345187,
         "hasc:id":"DO.PP",
+        "iso:code":"DO-18",
         "iso:id":"DO-18",
         "qs_pg:id":890053,
         "unlc:id":"DO-18",
         "wd:id":"Q693487",
         "wk:page":"Puerto Plata province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6682de35a11141fa6c0603185f643410",
+    "wof:geomhash":"c7db63589255fb44f2830aafb00f8af0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875422,
+    "wof:lastmodified":1695884897,
     "wof:name":"Puerto Plata",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/75/85670575.geojson
+++ b/data/856/705/75/85670575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06561,
-    "geom:area_square_m":765250553.831176,
+    "geom:area_square_m":765250337.296181,
     "geom:bbox":"-71.78629,19.228362,-71.425,19.582874",
     "geom:latitude":19.393,
     "geom:longitude":-71.593475,
@@ -240,17 +240,19 @@
         "gn:id":3508951,
         "gp:id":2345175,
         "hasc:id":"DO.DA",
+        "iso:code":"DO-05",
         "iso:id":"DO-05",
         "qs_pg:id":229370,
         "unlc:id":"DO-05",
         "wd:id":"Q1138575",
         "wk:page":"Dajab\u00f3n Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1defdd5e231cff391ee06fb66a9c6572",
+    "wof:geomhash":"f60e37f1f8295bdd9c59c84c8ea95b4b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -265,7 +267,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875419,
+    "wof:lastmodified":1695884363,
     "wof:name":"Dajab\u00f3n",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/81/85670581.geojson
+++ b/data/856/705/81/85670581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072632,
-    "geom:area_square_m":846405292.958417,
+    "geom:area_square_m":846405704.052192,
     "geom:bbox":"-70.605,19.307325,-70.084928,19.704338",
     "geom:latitude":19.535804,
     "geom:longitude":-70.391689,
@@ -287,17 +287,19 @@
         "gn:id":3505867,
         "gp:id":2345178,
         "hasc:id":"DO.ES",
+        "iso:code":"DO-09",
         "iso:id":"DO-09",
         "qs_pg:id":235581,
         "unlc:id":"DO-09",
         "wd:id":"Q530231",
         "wk:page":"Espaillat Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"23014b31c21d13772cdff0e951482ebe",
+    "wof:geomhash":"c7de6f4deedb8abca1334619c27461ad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875420,
+    "wof:lastmodified":1695884896,
     "wof:name":"Espaillat",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/83/85670583.geojson
+++ b/data/856/705/83/85670583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036825,
-    "geom:area_square_m":429444700.098897,
+    "geom:area_square_m":429444563.246754,
     "geom:bbox":"-70.459947,19.231444,-70.247536,19.559002",
     "geom:latitude":19.416689,
     "geom:longitude":-70.368841,
@@ -280,16 +280,18 @@
         "gn:id":3493282,
         "gp:id":2345188,
         "hasc:id":"DO.SC",
+        "iso:code":"DO-19",
         "iso:id":"DO-19",
         "qs_pg:id":318415,
         "wd:id":"Q549386",
         "wk:page":"Hermanas Mirabal Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e058090233702eb39d27eb6d93e9d31",
+    "wof:geomhash":"44f64c93baca12e9e7ca3e51d43318cb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875422,
+    "wof:lastmodified":1695884897,
     "wof:name":"Hermanas",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/89/85670589.geojson
+++ b/data/856/705/89/85670589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114168,
-    "geom:area_square_m":1338676728.5036,
+    "geom:area_square_m":1338676573.583294,
     "geom:bbox":"-71.681757,18.325237,-70.986479,18.655",
     "geom:latitude":18.510526,
     "geom:longitude":-71.344862,
@@ -288,16 +288,18 @@
         "gn:id":3512050,
         "gp:id":2345173,
         "hasc:id":"DO.BR",
+        "iso:code":"DO-03",
         "iso:id":"DO-03",
         "qs_pg:id":1108052,
         "unlc:id":"DO-03",
         "wd:id":"Q807079"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a93aa8ff57616605ba89f87b02f9daa",
+    "wof:geomhash":"ba706bac59de299fcbd0e2770a0b3a03",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875419,
+    "wof:lastmodified":1695884896,
     "wof:name":"Bahoruco",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/91/85670591.geojson
+++ b/data/856/705/91/85670591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141535,
-    "geom:area_square_m":1662853786.170092,
+    "geom:area_square_m":1662853916.556622,
     "geom:bbox":"-71.435212,17.859436,-70.948337,18.495",
     "geom:latitude":18.167436,
     "geom:longitude":-71.214319,
@@ -295,17 +295,19 @@
         "gn:id":3512042,
         "gp:id":2345174,
         "hasc:id":"DO.BH",
+        "iso:code":"DO-04",
         "iso:id":"DO-04",
         "qs_pg:id":219541,
         "unlc:id":"DO-04",
         "wd:id":"Q1137551",
         "wk:page":"Barahona Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e76b79352397e53ec90cdcd1a2d19a2",
+    "wof:geomhash":"2deb76c2e511553b06442498f37a5a8e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875420,
+    "wof:lastmodified":1695884896,
     "wof:name":"Barahona",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/705/97/85670597.geojson
+++ b/data/856/705/97/85670597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165941,
-    "geom:area_square_m":1946715316.755846,
+    "geom:area_square_m":1946715840.403639,
     "geom:bbox":"-72.007414,18.135,-71.21153,18.690833",
     "geom:latitude":18.424046,
     "geom:longitude":-71.622667,
@@ -281,17 +281,19 @@
         "gn:id":3504326,
         "gp:id":2345179,
         "hasc:id":"DO.IN",
+        "iso:code":"DO-10",
         "iso:id":"DO-10",
         "qs_pg:id":235582,
         "unlc:id":"DO-10",
         "wd:id":"Q1424401",
         "wk:page":"Independencia Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd6e3c8e81a6fd4eda29daa24b8235c3",
+    "wof:geomhash":"af7f7a7d1f602188e585399776c724f5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875421,
+    "wof:lastmodified":1695884897,
     "wof:name":"Independencia",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/01/85670601.geojson
+++ b/data/856/706/01/85670601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.118835,
-    "geom:area_square_m":1389360957.891047,
+    "geom:area_square_m":1389360660.856086,
     "geom:bbox":"-71.88632,18.654857,-71.324038,19.280896",
     "geom:latitude":18.999801,
     "geom:longitude":-71.610379,
@@ -307,15 +307,17 @@
         "gn:id":3507269,
         "gp:id":2345181,
         "hasc:id":"DO.EP",
+        "iso:code":"DO-07",
         "iso:id":"DO-07",
         "qs_pg:id":1135012,
         "wd:id":"Q1137545"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"73b5bbc6433c032a62395c2bbc7e0011",
+    "wof:geomhash":"66be1dbc1f323ac13a991a51e3654e1f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875417,
+    "wof:lastmodified":1695884895,
     "wof:name":"La Estrelleta",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/05/85670605.geojson
+++ b/data/856/706/05/85670605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173891,
-    "geom:area_square_m":2045431246.58085,
+    "geom:area_square_m":2045431513.135392,
     "geom:bbox":"-71.787545,17.537916,-71.270147,18.294779",
     "geom:latitude":17.958168,
     "geom:longitude":-71.535298,
@@ -292,17 +292,19 @@
         "gn:id":3495136,
         "gp:id":2345185,
         "hasc:id":"DO.PN",
+        "iso:code":"DO-16",
         "iso:id":"DO-16",
         "qs_pg:id":235583,
         "unlc:id":"DO-16",
         "wd:id":"Q1352533",
         "wk:page":"Pedernales Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"79a3ebe41a225908c6e7b09daaa98de8",
+    "wof:geomhash":"ac99a587d7944cf100cf62677c4283fb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875415,
+    "wof:lastmodified":1695884896,
     "wof:name":"Pedernales",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/09/85670609.geojson
+++ b/data/856/706/09/85670609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231235,
-    "geom:area_square_m":2710209064.983291,
+    "geom:area_square_m":2710208933.626661,
     "geom:bbox":"-71.164711,18.245388,-70.467795,19.004421",
     "geom:latitude":18.580949,
     "geom:longitude":-70.832641,
@@ -297,17 +297,19 @@
         "gn:id":3512209,
         "gp:id":2345172,
         "hasc:id":"DO.AZ",
+        "iso:code":"DO-02",
         "iso:id":"DO-02",
         "qs_pg:id":1285143,
         "unlc:id":"DO-02",
         "wd:id":"Q794239",
         "wk:page":"Azua Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6543f2e0b16dae165e782ca6de30ae55",
+    "wof:geomhash":"b598e6a62262d335eb179364c01fcd96",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -322,7 +324,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875416,
+    "wof:lastmodified":1695884896,
     "wof:name":"Azua",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/15/85670615.geojson
+++ b/data/856/706/15/85670615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196733,
-    "geom:area_square_m":2299344479.657606,
+    "geom:area_square_m":2299344296.290978,
     "geom:bbox":"-70.957799,18.686017,-70.27718,19.375",
     "geom:latitude":19.054666,
     "geom:longitude":-70.631058,
@@ -303,17 +303,19 @@
         "gn:id":3499977,
         "gp:id":2345198,
         "hasc:id":"DO.VE",
+        "iso:code":"DO-13",
         "iso:id":"DO-13",
         "qs_pg:id":423731,
         "unlc:id":"DO-13",
         "wd:id":"Q594405",
         "wk:page":"La Vega Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"55da64fbafebb5c0e92c35064abed67d",
+    "wof:geomhash":"9802cddad86e9722b3f5ca3fd169f144",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875418,
+    "wof:lastmodified":1695884896,
     "wof:name":"La Vega",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/19/85670619.geojson
+++ b/data/856/706/19/85670619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084963,
-    "geom:area_square_m":993903548.623709,
+    "geom:area_square_m":993903670.893421,
     "geom:bbox":"-70.583996,18.715,-70.225686,19.130757",
     "geom:latitude":18.905721,
     "geom:longitude":-70.414984,
@@ -293,17 +293,19 @@
         "gn:id":3496274,
         "gp:id":2345199,
         "hasc:id":"DO.MN",
+        "iso:code":"DO-28",
         "iso:id":"DO-28",
         "qs_pg:id":318427,
         "unlc:id":"DO-28",
         "wd:id":"Q1295496",
         "wk:page":"Monse\u00f1or Nouel Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b1854c8a0f0385a7fa9a3208ffc51c5",
+    "wof:geomhash":"d3179cf5c7945b1089efd97c3e4c8085",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875416,
+    "wof:lastmodified":1695884363,
     "wof:name":"Monse\u00f1or Nouel",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/23/85670623.geojson
+++ b/data/856/706/23/85670623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068642,
-    "geom:area_square_m":805692956.273926,
+    "geom:area_square_m":805692870.656275,
     "geom:bbox":"-70.588742,18.190416,-70.184617,18.506061",
     "geom:latitude":18.331751,
     "geom:longitude":-70.372472,
@@ -287,17 +287,19 @@
         "gn:id":3495015,
         "gp:id":2345186,
         "hasc:id":"DO.PV",
+        "iso:code":"DO-17",
         "iso:id":"DO-17",
         "qs_pg:id":1083822,
         "unlc:id":"DO-17",
         "wd:id":"Q1331932",
         "wk:page":"Peravia Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c65c1424e332ee5c56e19b86c3f27e4a",
+    "wof:geomhash":"b277ebea65eac6cb7f252ae8c4388044",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875418,
+    "wof:lastmodified":1695884896,
     "wof:name":"Peravia",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/27/85670627.geojson
+++ b/data/856/706/27/85670627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073402,
-    "geom:area_square_m":860125201.52631,
+    "geom:area_square_m":860125201.526279,
     "geom:bbox":"-70.6862078815,18.4221652082,-70.3461750744,18.7961844014",
     "geom:latitude":18.619505,
     "geom:longitude":-70.495276,
@@ -259,16 +259,18 @@
         "gn:id":6201372,
         "gp:id":28358195,
         "hasc:id":"DO.JO",
+        "iso:code":"DO-31",
         "iso:id":"DO-31",
         "qs_pg:id":203842,
         "unlc:id":"DO-31",
         "wd:id":"Q1424391"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3bacb3c92dbdaee87172e6746bab9517",
+    "wof:geomhash":"594a4c25487b9cff6d6063d0680fb260",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -283,7 +285,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582347711,
+    "wof:lastmodified":1695884363,
     "wof:name":"San Jos\u00e9 De Ocoa",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/33/85670633.geojson
+++ b/data/856/706/33/85670633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141871,
-    "geom:area_square_m":1656089475.466542,
+    "geom:area_square_m":1656089673.141915,
     "geom:bbox":"-70.365499,19.045357,-69.668238,19.521115",
     "geom:latitude":19.258955,
     "geom:longitude":-70.081461,
@@ -293,17 +293,19 @@
         "gn:id":3508718,
         "gp:id":2345177,
         "hasc:id":"DO.DU",
+        "iso:code":"DO-06",
         "iso:id":"DO-06",
         "qs_pg:id":235580,
         "unlc:id":"DO-06",
         "wd:id":"Q1262745",
         "wk:page":"Duarte Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a605f3101b2051a3499d9ae8637e25c",
+    "wof:geomhash":"109cb3a7ab8b78acddc1f450498eae1c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875414,
+    "wof:lastmodified":1695884895,
     "wof:name":"Duarte",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/37/85670637.geojson
+++ b/data/856/706/37/85670637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113398,
-    "geom:area_square_m":1326854112.016936,
+    "geom:area_square_m":1326853795.778885,
     "geom:bbox":"-69.625,18.525,-69.1227,19.104555",
     "geom:latitude":18.865438,
     "geom:longitude":-69.370856,
@@ -298,17 +298,19 @@
         "gn:id":3504766,
         "gp:id":2345197,
         "hasc:id":"DO.HM",
+        "iso:code":"DO-30",
         "iso:id":"DO-30",
         "qs_pg:id":423730,
         "unlc:id":"DO-30",
         "wd:id":"Q937217",
         "wk:page":"Hato Mayor Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dafe4a71e976498f20734bf443074ac4",
+    "wof:geomhash":"d6a502de2b35033084f11f5acb89cb46",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875416,
+    "wof:lastmodified":1695884896,
     "wof:name":"Hato Mayor",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/41/85670641.geojson
+++ b/data/856/706/41/85670641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.223184,
-    "geom:area_square_m":2611909865.442364,
+    "geom:area_square_m":2611909666.110657,
     "geom:bbox":"-70.248091,18.579806,-69.365,19.100953",
     "geom:latitude":18.836812,
     "geom:longitude":-69.799959,
@@ -299,17 +299,19 @@
         "gn:id":3496132,
         "gp:id":2345200,
         "hasc:id":"DO.MP",
+        "iso:code":"DO-29",
         "iso:id":"DO-29",
         "qs_pg:id":894874,
         "unlc:id":"DO-29",
         "wd:id":"Q1772745",
         "wk:page":"Monte Plata Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9cbbce55ed7805ef6b90546d7fda6a55",
+    "wof:geomhash":"7d69a9e6fc87b1dbcd49f418e2947da0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -324,7 +326,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875418,
+    "wof:lastmodified":1695884896,
     "wof:name":"Monte Plata",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/45/85670645.geojson
+++ b/data/856/706/45/85670645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104125,
-    "geom:area_square_m":1214063240.76598,
+    "geom:area_square_m":1214063236.17452,
     "geom:bbox":"-70.202974,19.208291,-69.744685,19.683722",
     "geom:latitude":19.448073,
     "geom:longitude":-69.968953,
@@ -292,16 +292,18 @@
         "gn:id":3496772,
         "gp:id":2345183,
         "hasc:id":"DO.MT",
+        "iso:code":"DO-14",
         "iso:id":"DO-14",
         "qs_pg:id":1135014,
         "unlc:id":"DO-14",
         "wd:id":"Q1949656"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2429771a459230b31c867724a4f13b8",
+    "wof:geomhash":"f24afee03024d56e708a6b120ad0b52a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875415,
+    "wof:lastmodified":1695884363,
     "wof:name":"Mar\u00eda Trinidad S\u00e1nchez",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/53/85670653.geojson
+++ b/data/856/706/53/85670653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074214,
-    "geom:area_square_m":866481633.467631,
+    "geom:area_square_m":866481958.116949,
     "geom:bbox":"-69.770342,18.994125,-69.150475,19.365417",
     "geom:latitude":19.227513,
     "geom:longitude":-69.481238,
@@ -297,17 +297,19 @@
         "gn:id":3493232,
         "gp:id":2345189,
         "hasc:id":"DO.SM",
+        "iso:code":"DO-20",
         "iso:id":"DO-20",
         "qs_pg:id":890054,
         "unlc:id":"DO-20",
         "wd:id":"Q1145487",
         "wk:page":"Saman\u00e1 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13fa6f4025fcccbb3f250f672d359c67",
+    "wof:geomhash":"adcb67ebaca047cf8797c4cbe2a10bf2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -322,7 +324,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875416,
+    "wof:lastmodified":1695884363,
     "wof:name":"Saman\u00e1",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/55/85670655.geojson
+++ b/data/856/706/55/85670655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10631,
-    "geom:area_square_m":1246443805.517176,
+    "geom:area_square_m":1246443852.571896,
     "geom:bbox":"-70.380481,18.226223,-70.004261,18.805",
     "geom:latitude":18.522497,
     "geom:longitude":-70.20613,
@@ -304,17 +304,19 @@
         "gn:id":3493186,
         "gp:id":2345201,
         "hasc:id":"DO.CR",
+        "iso:code":"DO-21",
         "iso:id":"DO-21",
         "qs_pg:id":894875,
         "unlc:id":"DO-21",
         "wd:id":"Q1366107",
         "wk:page":"San Crist\u00f3bal Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f3b7716aef5c70b71270a08986d4e3c",
+    "wof:geomhash":"5a420450abb2b95419a991b51baedd2f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875417,
+    "wof:lastmodified":1695884363,
     "wof:name":"San Crist\u00f3bal",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/59/85670659.geojson
+++ b/data/856/706/59/85670659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007833,
-    "geom:area_square_m":91860163.013164,
+    "geom:area_square_m":91860028.731551,
     "geom:bbox":"-69.999712,18.423073,-69.878789,18.544211",
     "geom:latitude":18.483467,
     "geom:longitude":-69.942434,
@@ -236,16 +236,18 @@
         "gn:id":3496024,
         "gp:id":2345176,
         "hasc:id":"DO.NC",
+        "iso:code":"DO-01",
         "iso:id":"DO-01",
         "qs_pg:id":1083821,
         "wd:id":"Q2499228",
         "wk:page":"Distrito Nacional"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c854c6e14a01bef54cfb4be552daf7d2",
+    "wof:geomhash":"5d77d4183c0920784e254e35652483d6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -260,7 +262,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875414,
+    "wof:lastmodified":1695884895,
     "wof:name":"Distrito Nacional",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/63/85670663.geojson
+++ b/data/856/706/63/85670663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15359,
-    "geom:area_square_m":1797641768.519476,
+    "geom:area_square_m":1797641716.774992,
     "geom:bbox":"-69.325648,18.52473,-68.782895,19.043751",
     "geom:latitude":18.818491,
     "geom:longitude":-69.046694,
@@ -304,17 +304,19 @@
         "gn:id":3506189,
         "gp:id":2345196,
         "hasc:id":"DO.SE",
+        "iso:code":"DO-08",
         "iso:id":"DO-08",
         "qs_pg:id":219545,
         "unlc:id":"DO-08",
         "wd:id":"Q1774831",
         "wk:page":"El Seibo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b67fe3789aa37a8c436e4e9d3f58d405",
+    "wof:geomhash":"aad68473d6d5a0eb02ccc7da5222fe56",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875417,
+    "wof:lastmodified":1695884896,
     "wof:name":"El Seybo",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/69/85670669.geojson
+++ b/data/856/706/69/85670669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.257053,
-    "geom:area_square_m":3012875939.964672,
+    "geom:area_square_m":3012875443.347102,
     "geom:bbox":"-68.933946,18.201221,-68.325417,18.972255",
     "geom:latitude":18.577327,
     "geom:longitude":-68.657283,
@@ -293,17 +293,19 @@
         "gn:id":3503706,
         "gp:id":2345180,
         "hasc:id":"DO.AL",
+        "iso:code":"DO-11",
         "iso:id":"DO-11",
         "qs_pg:id":913534,
         "unlc:id":"DO-11",
         "wd:id":"Q1323353",
         "wk:page":"La Altagracia Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"786aa06d9c7d5c70e50ebc59a98a4021",
+    "wof:geomhash":"7b2e7758a43a014fae0165565bd68973",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875414,
+    "wof:lastmodified":1695884895,
     "wof:name":"La Altagracia",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/856/706/73/85670673.geojson
+++ b/data/856/706/73/85670673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056354,
-    "geom:area_square_m":661039747.623831,
+    "geom:area_square_m":661040285.601179,
     "geom:bbox":"-69.115954,18.107889,-68.571281,18.65597",
     "geom:latitude":18.442299,
     "geom:longitude":-68.923834,
@@ -314,16 +314,18 @@
         "gn:id":3500955,
         "gp:id":2345182,
         "hasc:id":"DO.RO",
+        "iso:code":"DO-12",
         "iso:id":"DO-12",
         "qs_pg:id":1135013,
         "unlc:id":"DO-12",
         "wd:id":"Q1140742"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"025e18bc697cd88a6bbfb00d7912d580",
+    "wof:geomhash":"3e65450cbebb68b6fd7202e529216f0b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690875415,
+    "wof:lastmodified":1695884896,
     "wof:name":"La Romana",
     "wof:parent_id":85632713,
     "wof:placetype":"region",

--- a/data/890/420/137/890420137.geojson
+++ b/data/890/420/137/890420137.geojson
@@ -80,6 +80,7 @@
         "qs_pg:id":95786,
         "wk:page":"El Llano"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051319,
     "wof:geom_alt":[
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":890420137,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"El Llano",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/890/420/141/890420141.geojson
+++ b/data/890/420/141/890420141.geojson
@@ -99,6 +99,7 @@
         "wd:id":"Q3720911",
         "wk:page":"El Factor"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051319,
     "wof:geom_alt":[
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890420141,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"El Factor",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/420/143/890420143.geojson
+++ b/data/890/420/143/890420143.geojson
@@ -99,6 +99,7 @@
         "wd:id":"Q3720880",
         "wk:page":"El Cercado"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051319,
     "wof:geom_alt":[
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890420143,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"El Cercado",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/890/420/145/890420145.geojson
+++ b/data/890/420/145/890420145.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q3716731",
         "wk:page":"Duverg\u00e9"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051319,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890420145,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Duverg\u00e9",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/890/420/147/890420147.geojson
+++ b/data/890/420/147/890420147.geojson
@@ -193,6 +193,7 @@
         "wd:id":"Q2087489",
         "wk:page":"Cotu\u00ed"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051320,
     "wof:geom_alt":[
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":890420147,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Cotu\u00ed",
     "wof:parent_id":85670557,
     "wof:placetype":"county",

--- a/data/890/420/149/890420149.geojson
+++ b/data/890/420/149/890420149.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q3665682",
         "wk:page":"Cevicos"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051320,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890420149,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Cevicos",
     "wof:parent_id":85670557,
     "wof:placetype":"county",

--- a/data/890/425/729/890425729.geojson
+++ b/data/890/425/729/890425729.geojson
@@ -300,6 +300,7 @@
         "wd:id":"Q1770877",
         "wk:page":"Tenares"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051601,
     "wof:geom_alt":[
@@ -315,7 +316,7 @@
         }
     ],
     "wof:id":890425729,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"Tenares",
     "wof:parent_id":85670583,
     "wof:placetype":"county",

--- a/data/890/429/183/890429183.geojson
+++ b/data/890/429/183/890429183.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q4022462",
         "wk:page":"Yamas\u00e1"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051799,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429183,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886547,
     "wof:name":"Yamas\u00e1",
     "wof:parent_id":85670641,
     "wof:placetype":"county",

--- a/data/890/429/185/890429185.geojson
+++ b/data/890/429/185/890429185.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q4022373",
         "wk:page":"Yaguate"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051799,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429185,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886547,
     "wof:name":"Yaguate",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/890/429/189/890429189.geojson
+++ b/data/890/429/189/890429189.geojson
@@ -99,6 +99,7 @@
         "wd:id":"Q1770889",
         "wk:page":"Villa Tapia"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051799,
     "wof:geom_alt":[
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890429189,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886547,
     "wof:name":"Villa Tapia",
     "wof:parent_id":85670583,
     "wof:placetype":"county",

--- a/data/890/429/191/890429191.geojson
+++ b/data/890/429/191/890429191.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q949768",
         "wk:page":"Villa Riva"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890429191,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886548,
     "wof:name":"Villa Riva",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/890/429/195/890429195.geojson
+++ b/data/890/429/195/890429195.geojson
@@ -105,6 +105,7 @@
         "wd:id":"Q4012143",
         "wk:page":"Villa Jaragua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":890429195,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886545,
     "wof:name":"Villa Jaragua",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/890/429/197/890429197.geojson
+++ b/data/890/429/197/890429197.geojson
@@ -99,6 +99,7 @@
         "wd:id":"Q4012142",
         "wk:page":"Villa Isabela"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890429197,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886545,
     "wof:name":"Villa Isabela",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/199/890429199.geojson
+++ b/data/890/429/199/890429199.geojson
@@ -105,6 +105,7 @@
         "wd:id":"Q4011765",
         "wk:page":"Villa Altagracia"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":890429199,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886545,
     "wof:name":"Villa Altagracia",
     "wof:parent_id":85670655,
     "wof:placetype":"county",

--- a/data/890/429/201/890429201.geojson
+++ b/data/890/429/201/890429201.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q1770645",
         "wk:page":"Vicente Noble"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429201,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Vicente Noble",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/890/429/203/890429203.geojson
+++ b/data/890/429/203/890429203.geojson
@@ -93,6 +93,7 @@
         "wd:id":"Q4008204",
         "wk:page":"Vallejuelo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":890429203,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886545,
     "wof:name":"Vallejuelo",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/890/429/205/890429205.geojson
+++ b/data/890/429/205/890429205.geojson
@@ -92,6 +92,7 @@
         "qs_pg:id":95712,
         "wk:page":"Tamayo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":890429205,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Tamayo",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/890/429/207/890429207.geojson
+++ b/data/890/429/207/890429207.geojson
@@ -114,6 +114,7 @@
         "wd:id":"Q1639488",
         "wk:page":"Sos\u00faa"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051800,
     "wof:geom_alt":[
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":890429207,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Sos\u00faa",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/213/890429213.geojson
+++ b/data/890/429/213/890429213.geojson
@@ -115,6 +115,7 @@
         "wd:id":"Q681999",
         "wk:page":"San Francisco de Macor\u00eds"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051801,
     "wof:geom_alt":[
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":890429213,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886545,
     "wof:name":"San Francisco De Macor\u00eds",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/890/429/217/890429217.geojson
+++ b/data/890/429/217/890429217.geojson
@@ -72,6 +72,7 @@
         "wd:id":"Q3944200",
         "wk:page":"Sabana Grande de Boy\u00e1"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051801,
     "wof:geom_alt":[
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":890429217,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886393,
     "wof:name":"Sabana Grande De Boy\u00e1",
     "wof:parent_id":85670641,
     "wof:placetype":"county",

--- a/data/890/429/219/890429219.geojson
+++ b/data/890/429/219/890429219.geojson
@@ -72,6 +72,7 @@
         "wd:id":"Q3944208",
         "wk:page":"Sabana de la Mar"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051801,
     "wof:geom_alt":[
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":890429219,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886393,
     "wof:name":"Sabana De La Mar",
     "wof:parent_id":85670637,
     "wof:placetype":"county",

--- a/data/890/429/221/890429221.geojson
+++ b/data/890/429/221/890429221.geojson
@@ -81,6 +81,7 @@
         "hasc:id":"DO.PM.RS",
         "qs_pg:id":95734
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051801,
     "wof:geom_alt":[
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890429221,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886543,
     "wof:name":"Ram\u00f3n Santana",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/890/429/223/890429223.geojson
+++ b/data/890/429/223/890429223.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q3909478",
         "wk:page":"Postrer R\u00edo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051801,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890429223,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Postrer R\u00edo",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/890/429/225/890429225.geojson
+++ b/data/890/429/225/890429225.geojson
@@ -113,6 +113,7 @@
         "qs_pg:id":95742,
         "wk:page":"Para\u00edso"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051801,
     "wof:geom_alt":[
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":890429225,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Para\u00edso",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/890/429/227/890429227.geojson
+++ b/data/890/429/227/890429227.geojson
@@ -104,6 +104,7 @@
         "qs_pg:id":95743,
         "wk:page":"Padre Las Casas, Chile"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051802,
     "wof:geom_alt":[
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890429227,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"Padre Las Casas",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/890/429/231/890429231.geojson
+++ b/data/890/429/231/890429231.geojson
@@ -344,6 +344,7 @@
         "qs_pg:id":95744,
         "wk:page":"Oviedo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051802,
     "wof:geom_alt":[
@@ -359,7 +360,7 @@
         }
     ],
     "wof:id":890429231,
-    "wof:lastmodified":1694497897,
+    "wof:lastmodified":1695886791,
     "wof:name":"Oviedo",
     "wof:parent_id":85670605,
     "wof:placetype":"county",

--- a/data/890/429/233/890429233.geojson
+++ b/data/890/429/233/890429233.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q3877399",
         "wk:page":"Nizao"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051802,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429233,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Nizao",
     "wof:parent_id":85670623,
     "wof:placetype":"county",

--- a/data/890/429/235/890429235.geojson
+++ b/data/890/429/235/890429235.geojson
@@ -195,6 +195,7 @@
         "wd:id":"Q2107258",
         "wk:page":"Neiba"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051802,
     "wof:geom_alt":[
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":890429235,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886790,
     "wof:name":"Neiba",
     "wof:parent_id":85670589,
     "wof:placetype":"county",

--- a/data/890/429/237/890429237.geojson
+++ b/data/890/429/237/890429237.geojson
@@ -193,6 +193,7 @@
         "wd:id":"Q2306984",
         "wk:page":"Nagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051802,
     "wof:geom_alt":[
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":890429237,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886790,
     "wof:name":"Nagua",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/429/239/890429239.geojson
+++ b/data/890/429/239/890429239.geojson
@@ -99,6 +99,7 @@
         "wd:id":"Q3307947",
         "wk:page":"Monci\u00f3n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051802,
     "wof:geom_alt":[
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890429239,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886543,
     "wof:name":"Monci\u00f3n",
     "wof:parent_id":85670543,
     "wof:placetype":"county",

--- a/data/890/429/241/890429241.geojson
+++ b/data/890/429/241/890429241.geojson
@@ -101,6 +101,7 @@
         "qs_pg:id":95752,
         "wk:page":"Moca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051803,
     "wof:geom_alt":[
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890429241,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886790,
     "wof:name":"Moca",
     "wof:parent_id":85670581,
     "wof:placetype":"county",

--- a/data/890/429/243/890429243.geojson
+++ b/data/890/429/243/890429243.geojson
@@ -99,6 +99,7 @@
         "wd:id":"Q1770668",
         "wk:page":"Miches"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051803,
     "wof:geom_alt":[
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890429243,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"Miches",
     "wof:parent_id":85670663,
     "wof:placetype":"county",

--- a/data/890/429/249/890429249.geojson
+++ b/data/890/429/249/890429249.geojson
@@ -75,6 +75,7 @@
         "hasc:id":"DO.VA.MA",
         "qs_pg:id":95756
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051803,
     "wof:geom_alt":[
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890429249,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886790,
     "wof:name":"Mao",
     "wof:parent_id":85670545,
     "wof:placetype":"county",

--- a/data/890/429/251/890429251.geojson
+++ b/data/890/429/251/890429251.geojson
@@ -75,6 +75,7 @@
         "wd:id":"Q6735878",
         "wk:page":"Maim\u00f3n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051803,
     "wof:geom_alt":[
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890429251,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886543,
     "wof:name":"Maim\u00f3n",
     "wof:parent_id":85670619,
     "wof:placetype":"county",

--- a/data/890/429/253/890429253.geojson
+++ b/data/890/429/253/890429253.geojson
@@ -74,6 +74,7 @@
         "qs_pg:id":95758,
         "wk:page":"Luper\u00f3n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051804,
     "wof:geom_alt":[
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":890429253,
-    "wof:lastmodified":1694498048,
+    "wof:lastmodified":1695886543,
     "wof:name":"Luper\u00f3n",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/255/890429255.geojson
+++ b/data/890/429/255/890429255.geojson
@@ -63,6 +63,7 @@
         "hasc:id":"DO.PM.LL",
         "qs_pg:id":95759
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051804,
     "wof:geom_alt":[
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":890429255,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886338,
     "wof:name":"Los Llanos",
     "wof:parent_id":85670563,
     "wof:placetype":"county",

--- a/data/890/429/257/890429257.geojson
+++ b/data/890/429/257/890429257.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q518820",
         "wk:page":"Los Hidalgos"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051804,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890429257,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Los Hidalgos",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/259/890429259.geojson
+++ b/data/890/429/259/890429259.geojson
@@ -75,6 +75,7 @@
         "wd:id":"Q1771467",
         "wk:page":"Loma de Cabrera"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051804,
     "wof:geom_alt":[
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890429259,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886271,
     "wof:name":"Cabrera",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/429/261/890429261.geojson
+++ b/data/890/429/261/890429261.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q3831982",
         "wk:page":"Licey al Medio"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051804,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890429261,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Licey Al Medio",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/890/429/263/890429263.geojson
+++ b/data/890/429/263/890429263.geojson
@@ -69,6 +69,7 @@
         "wd:id":"Q3827245",
         "wk:page":"Las Matas de Santa Cruz"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051804,
     "wof:geom_alt":[
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":890429263,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886328,
     "wof:name":"Las Matas De Santa Cruz",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/890/429/267/890429267.geojson
+++ b/data/890/429/267/890429267.geojson
@@ -69,6 +69,7 @@
         "wd:id":"Q3827246",
         "wk:page":"Las Matas de Farf\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":890429267,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886328,
     "wof:name":"Las Matas De Farf\u00e1n",
     "wof:parent_id":85670549,
     "wof:placetype":"county",

--- a/data/890/429/269/890429269.geojson
+++ b/data/890/429/269/890429269.geojson
@@ -123,6 +123,7 @@
         "wd:id":"Q990182",
         "wk:page":"Jarabacoa"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":890429269,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Jarabacoa",
     "wof:parent_id":85670615,
     "wof:placetype":"county",

--- a/data/890/429/271/890429271.geojson
+++ b/data/890/429/271/890429271.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q1770660",
         "wk:page":"J\u00e1nico"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890429271,
-    "wof:lastmodified":1694497897,
+    "wof:lastmodified":1695886791,
     "wof:name":"J\u00e1nico",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/890/429/273/890429273.geojson
+++ b/data/890/429/273/890429273.geojson
@@ -77,6 +77,7 @@
         "qs_pg:id":95774,
         "wk:page":"Imbert"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":890429273,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"Imbert",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/429/275/890429275.geojson
+++ b/data/890/429/275/890429275.geojson
@@ -84,6 +84,7 @@
         "hasc:id":"DO.EP.HV",
         "qs_pg:id":95775
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890429275,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886541,
     "wof:name":"Hondo Valle",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/890/429/277/890429277.geojson
+++ b/data/890/429/277/890429277.geojson
@@ -68,6 +68,7 @@
         "qs_pg:id":95776,
         "wk:page":"Hig\u00fcey"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":890429277,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886301,
     "wof:name":"Hig\u00fcey",
     "wof:parent_id":85670669,
     "wof:placetype":"county",

--- a/data/890/429/279/890429279.geojson
+++ b/data/890/429/279/890429279.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q377948",
         "wk:page":"Guayub\u00edn"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429279,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Guayub\u00edn",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/890/429/281/890429281.geojson
+++ b/data/890/429/281/890429281.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q628537",
         "wk:page":"Guaymate"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429281,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Guaymate",
     "wof:parent_id":85670673,
     "wof:placetype":"county",

--- a/data/890/429/285/890429285.geojson
+++ b/data/890/429/285/890429285.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q3758618",
         "wk:page":"Gaspar Hern\u00e1ndez"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429285,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Gaspar Hern\u00e1ndez",
     "wof:parent_id":85670581,
     "wof:placetype":"county",

--- a/data/890/429/287/890429287.geojson
+++ b/data/890/429/287/890429287.geojson
@@ -105,6 +105,7 @@
         "wd:id":"Q3739410",
         "wk:page":"Fantino"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":890429287,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"Fantino",
     "wof:parent_id":85670557,
     "wof:placetype":"county",

--- a/data/890/429/289/890429289.geojson
+++ b/data/890/429/289/890429289.geojson
@@ -140,6 +140,7 @@
         "qs_pg:id":95782,
         "wk:page":"Esperanza"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051805,
     "wof:geom_alt":[
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":890429289,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886790,
     "wof:name":"Esperanza",
     "wof:parent_id":85670545,
     "wof:placetype":"county",

--- a/data/890/429/291/890429291.geojson
+++ b/data/890/429/291/890429291.geojson
@@ -108,6 +108,7 @@
         "wd:id":"Q1344189",
         "wk:page":"Enriquillo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051806,
     "wof:geom_alt":[
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":890429291,
-    "wof:lastmodified":1694497897,
+    "wof:lastmodified":1695886791,
     "wof:name":"Enriquillo",
     "wof:parent_id":85670591,
     "wof:placetype":"county",

--- a/data/890/429/293/890429293.geojson
+++ b/data/890/429/293/890429293.geojson
@@ -149,6 +149,7 @@
         "qs_pg:id":95816,
         "wk:page":"Altamira"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469051806,
     "wof:geom_alt":[
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":890429293,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886790,
     "wof:name":"Altamira",
     "wof:parent_id":85670571,
     "wof:placetype":"county",

--- a/data/890/436/811/890436811.geojson
+++ b/data/890/436/811/890436811.geojson
@@ -86,6 +86,7 @@
         "qs_pg:id":95732,
         "wk:page":"R\u00edo San Juan"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052127,
     "wof:geom_alt":[
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":890436811,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"R\u00edo San Juan",
     "wof:parent_id":85670645,
     "wof:placetype":"county",

--- a/data/890/438/115/890438115.geojson
+++ b/data/890/438/115/890438115.geojson
@@ -86,6 +86,7 @@
         "qs_pg:id":95784,
         "wk:page":"El Valle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052181,
     "wof:geom_alt":[
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":890438115,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"El Valle",
     "wof:parent_id":85670637,
     "wof:placetype":"county",

--- a/data/890/453/401/890453401.geojson
+++ b/data/890/453/401/890453401.geojson
@@ -89,6 +89,7 @@
         "qs_pg:id":95794,
         "wk:page":"Constanza"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052852,
     "wof:geom_alt":[
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":890453401,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"Constanza",
     "wof:parent_id":85670615,
     "wof:placetype":"county",

--- a/data/890/453/405/890453405.geojson
+++ b/data/890/453/405/890453405.geojson
@@ -83,6 +83,7 @@
         "qs_pg:id":95795,
         "wk:page":"Comendador"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052852,
     "wof:geom_alt":[
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":890453405,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886789,
     "wof:name":"Comendador",
     "wof:parent_id":85670601,
     "wof:placetype":"county",

--- a/data/890/455/299/890455299.geojson
+++ b/data/890/455/299/890455299.geojson
@@ -93,6 +93,7 @@
         "wd:id":"Q649483",
         "wk:page":"San Rafael del Yuma"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":890455299,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"San Rafael Del Yuma",
     "wof:parent_id":85670669,
     "wof:placetype":"county",

--- a/data/890/455/301/890455301.geojson
+++ b/data/890/455/301/890455301.geojson
@@ -66,6 +66,7 @@
         "wd:id":"Q3947426",
         "wk:page":"San Jos\u00e9 de las Matas"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":890455301,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886395,
     "wof:name":"San Jos\u00e9 De Las Matas",
     "wof:parent_id":85670537,
     "wof:placetype":"county",

--- a/data/890/455/303/890455303.geojson
+++ b/data/890/455/303/890455303.geojson
@@ -113,6 +113,7 @@
         "qs_pg:id":95737,
         "wk:page":"Pimentel"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":890455303,
-    "wof:lastmodified":1694498108,
+    "wof:lastmodified":1695886789,
     "wof:name":"Pimentel",
     "wof:parent_id":85670633,
     "wof:placetype":"county",

--- a/data/890/455/305/890455305.geojson
+++ b/data/890/455/305/890455305.geojson
@@ -101,6 +101,7 @@
         "qs_pg:id":95738,
         "wk:page":"Peralta"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890455305,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"Peralta",
     "wof:parent_id":85670609,
     "wof:placetype":"county",

--- a/data/890/455/307/890455307.geojson
+++ b/data/890/455/307/890455307.geojson
@@ -63,6 +63,7 @@
         "hasc:id":"DO.MC.PS",
         "qs_pg:id":95739
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":890455307,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886375,
     "wof:name":"Pepillo Salcedo",
     "wof:parent_id":85670567,
     "wof:placetype":"county",

--- a/data/890/455/313/890455313.geojson
+++ b/data/890/455/313/890455313.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q1770074",
         "wk:page":"Laguna Salada"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890455313,
-    "wof:lastmodified":1694498047,
+    "wof:lastmodified":1695886541,
     "wof:name":"Laguna Salada",
     "wof:parent_id":85670545,
     "wof:placetype":"county",

--- a/data/890/455/315/890455315.geojson
+++ b/data/890/455/315/890455315.geojson
@@ -105,6 +105,7 @@
         "wd:id":"Q3820813",
         "wk:page":"La Descubierta"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":890455315,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886789,
     "wof:name":"La Descubierta",
     "wof:parent_id":85670597,
     "wof:placetype":"county",

--- a/data/890/455/317/890455317.geojson
+++ b/data/890/455/317/890455317.geojson
@@ -186,6 +186,7 @@
         "wd:id":"Q1409818",
         "wk:page":"Jiman\u00ed"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"DO",
     "wof:created":1469052942,
     "wof:geom_alt":[
@@ -201,7 +202,7 @@
         }
     ],
     "wof:id":890455317,
-    "wof:lastmodified":1694497896,
+    "wof:lastmodified":1695886790,
     "wof:name":"Jiman\u00ed",
     "wof:parent_id":85670597,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.